### PR TITLE
fix anchor self-links

### DIFF
--- a/Bundle-Layout.md
+++ b/Bundle-Layout.md
@@ -8,11 +8,11 @@ Implements Danny Holten's [hierarchical edge bundling](http://citeseerx.ist.psu.
 
 For example, consider this visualization of [software dependencies](http://bl.ocks.org/mbostock/1044242).
 
-<a name="bundle" href="Bundle-Layout#bundle">#</a> d3.layout.<b>bundle</b>()
+<a name="bundle" href="Bundle-Layout.md#bundle">#</a> d3.layout.<b>bundle</b>()
 
 Constructs a new default bundle layout. Currently, the bundle layout is stateless and thus only has a default configuration. The returned layout object is both an object and a function. That is: you can call the layout like any other function, and the layout has additional methods that change its behavior. Like other classes in D3, layouts follow the method chaining pattern where setter methods return the layout itself, allowing multiple setters to be invoked in a concise statement.
 
-<a name="_bundle" href="Bundle-Layout#_bundle">#</a> <b>bundle</b>(<i>links</i>)
+<a name="_bundle" href="Bundle-Layout.md#_bundle">#</a> <b>bundle</b>(<i>links</i>)
 
 Evaluates the bundle layout on the specified array of *links*, returning the computed path from the source to the target, through the [least common ancestor](http://en.wikipedia.org/wiki/Lowest_common_ancestor). Each input link must have two attributes:
 

--- a/CSV.md
+++ b/CSV.md
@@ -52,7 +52,7 @@ d3.csv("example.csv", function(d) {
 
 Using + rather than [parseInt](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/parseInt) or [parseFloat](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/parseFloat) is typically faster, though more restrictive. For example, "30px" when coerced using + returns NaN, while parseInt and parseFloat return 30.
 
-<a name="parseRows" href="CSV#parseRows">#</a> d3.csv.<b>parseRows</b>(<i>string</i>[, <i>accessor</i>])
+<a name="parseRows" href="CSV.md#parseRows">#</a> d3.csv.<b>parseRows</b>(<i>string</i>[, <i>accessor</i>])
 
 Parses the specified *string*, which is the contents of a CSV file, returning an array of arrays representing the parsed rows. The string is assumed to be [RFC4180-compliant](http://tools.ietf.org/html/rfc4180). Unlike the [parse](CSV.md#parse) method, this method treats the header line as a standard row, and should be used whenever the CSV file does not contain a header. Each row is represented as an array rather than an object. Rows may have variable length. For example, consider the following CSV file:
 
@@ -74,13 +74,13 @@ Note that the values themselves are always strings; they will not be automatical
 
 An optional *accessor* function may be specified as the second argument. This function is invoked for each row in the CSV file, being passed the current row and index as two arguments. The return value of the function replaces the element in the returned array of rows; if the function returns null, the row is stripped from the returned array of rows. In effect, the accessor is similar to applying a [map](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/map) and [filter](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/filter) operator to the returned rows. The accessor function is used by [parse](CSV.md#parse) to convert each row to an object with named attributes.
 
-<a name="format" href="CSV#format">#</a> d3.csv.<b>format</b>(<i>rows</i>)
+<a name="format" href="CSV.md#format">#</a> d3.csv.<b>format</b>(<i>rows</i>)
 
 Converts the specified array of *rows* into comma-separated values format, returning a string. This operation is the reverse of [parse](CSV.md#parse). Each row will be separated by a newline (\n), and each column within each row will be separated by a comma (,). Values that contain either commas, double-quotes (") or newlines will be escaped using double-quotes.
 
 Each row should be an object, and all object properties will be converted into fields.  For greater control over which properties are converted, convert the rows into arrays containing only the properties that should be converted and use [formatRows](CSV.md#formatRows).
 
-<a name="formatRows" href="CSV#formatRows">#</a> d3.csv.<b>formatRows</b>(<i>rows</i>)
+<a name="formatRows" href="CSV.md#formatRows">#</a> d3.csv.<b>formatRows</b>(<i>rows</i>)
 
 Converts the specified array of *rows* into comma-separated values format, returning a string. This operation is the reverse of [parseRows](CSV.md#parseRows). Each row will be separated by a newline (\n), and each column within each row will be separated by a comma (,). Values that contain either commas, double-quotes (") or newlines will be escaped using double-quotes.
 

--- a/Chord-Layout.md
+++ b/Chord-Layout.md
@@ -10,11 +10,11 @@ A chord diagram visualizes these relationships by drawing quadratic Bézier curv
 
 The chord layout is designed to work in conjunction with the [chord shape](SVG-Shapes.md#chord) and the [arc shape](SVG-Shapes.md#arc). The layout is used to generate data objects which describe the chords, serving as input to the chord shape. The layout also generates descriptions for the groups, which can be used as input to the arc shape.
 
-<a name="chord" href="Chord-Layout#chord">#</a> d3.layout.<b>chord</b>()
+<a name="chord" href="Chord-Layout.md#chord">#</a> d3.layout.<b>chord</b>()
 
 Constructs a new chord layout. By default, the input data is not sorted, and there is no padding between groups. Unlike some of the other layouts, the chord layout is not a function to be applied to data; instead, data is specified by setting the associated [matrix](Chord-Layout.md#matrix), and retrieved using the [chords](Chord-Layout.md#chords) and [groups](Chord-Layout.md#groups) accessors.
 
-<a name="matrix" href="Chord-Layout#matrix">#</a> chord.<b>matrix</b>([<i>matrix</i>])
+<a name="matrix" href="Chord-Layout.md#matrix">#</a> chord.<b>matrix</b>([<i>matrix</i>])
 
 If *matrix* is specified, sets the input data matrix used by this layout. If *matrix* is not specified, returns the current data matrix, which defaults to undefined. The input matrix must be a [square matrix](http://en.wikipedia.org/wiki/Matrix_(mathematics)#Square_matrices) of numbers, such as:
 
@@ -27,23 +27,23 @@ If *matrix* is specified, sets the input data matrix used by this layout. If *ma
 
 Each row in the matrix corresponds to a distinct group, such as a hair color in the above example. Each column *i* in the matrix corresponds to the same group as row *i*; the cell *ij* corresponds to the relationship from group *i* to group *j*.
 
-<a name="padding" href="Chord-Layout#padding">#</a> chord.<b>padding</b>([<i>padding</i>])
+<a name="padding" href="Chord-Layout.md#padding">#</a> chord.<b>padding</b>([<i>padding</i>])
 
 If *padding* is specified, sets the angular padding between groups to the specified value in [radians](http://en.wikipedia.org/wiki/Radian). If *padding* is not specified, returns the current padding, which defaults to zero. You may wish to compute the padding as a function of the number of groups (the number of rows or columns in the associated matrix).
 
-<a name="sortGroups" href="Chord-Layout#sortGroups">#</a> chord.<b>sortGroups</b>([<i>comparator</i>])
+<a name="sortGroups" href="Chord-Layout.md#sortGroups">#</a> chord.<b>sortGroups</b>([<i>comparator</i>])
 
 If *comparator* is specified, sets the sort order of groups (rows) for the layout using the specified comparator function. The comparator function is invoked for pairs of rows, being passed the sum of row *i* and row *j*. Typically, the comparator should be specified as either [d3.ascending](Arrays.md#d3_ascending) or [d3.descending](Arrays.md#d3_descending). If *comparator* is not specified, returns the current group sort order, which defaults to null for no sorting.
 
-<a name="sortSubgroups" href="Chord-Layout#sortSubgroups">#</a> chord.<b>sortSubgroups</b>([<i>comparator</i>])
+<a name="sortSubgroups" href="Chord-Layout.md#sortSubgroups">#</a> chord.<b>sortSubgroups</b>([<i>comparator</i>])
 
 If *comparator* is specified, sets the sort order of subgroups (columns within rows) for the layout using the specified comparator function. The comparator function is invoked for pairs of cells, being passed the value of each cell. Typically, the comparator should be specified as either ascending or descending. If *comparator* is not specified, returns the current subgroup sort order, which defaults to null for no sorting.
 
-<a name="sortChords" href="Chord-Layout#sortChords">#</a> chord.<b>sortChords</b>([<i>comparator</i>])
+<a name="sortChords" href="Chord-Layout.md#sortChords">#</a> chord.<b>sortChords</b>([<i>comparator</i>])
 
 If *comparator* is specified, sets the sort order of chords (z-order) for the layout using the specified comparator function. The comparator function is invoked for pairs of chords, being passed the minimum value of the associated source and target cells. Typically, the comparator should be specified as either ascending or descending. If *comparator* is not specified, returns the current chord sort order, which defaults to null for no sorting.
 
-<a name="chords" href="Chord-Layout#chords">#</a> chord.<b>chords</b>()
+<a name="chords" href="Chord-Layout.md#chords">#</a> chord.<b>chords</b>()
 
 Returns the computed chord objects, given the layout's current configuration and associated matrix. If the chord objects were previously-computed, this method returns the cached value. Changing any attribute of the layout implicitly clears the previously-computed chords, if any, such that the next call to this method will recompute the layout. The returned objects have the following properties:
 
@@ -60,7 +60,7 @@ These objects, in turn, describe the underlying entity:
 
 Note that these objects conveniently match the default accessors for the [chord](SVG-Shapes.md#chord) generator; however, you can still override the accessors to tweak the layout, or simply manipulate the returned objects.
 
-<a name="groups" href="Chord-Layout#groups">#</a> chord.<b>groups</b>()
+<a name="groups" href="Chord-Layout.md#groups">#</a> chord.<b>groups</b>()
 
 Returns the computed group objects, given the layout's current configuration and associated matrix. If the group objects were previously-computed, this method returns the cached value. Changing any attribute of the layout implicitly clears the previously-computed groups, if any, such that the next call to this method will recompute the layout. The returned objects have the following properties:
 

--- a/Drag-Behavior.md
+++ b/Drag-Behavior.md
@@ -4,7 +4,7 @@
 
 This behavior automatically creates event listeners to handle drag gestures on an element. Both mouse events and touch events are supported.
 
-<a name="drag" href="Drag-Behavior#drag">#</a> d3.behavior.<b>drag</b>()
+<a name="drag" href="Drag-Behavior.md#drag">#</a> d3.behavior.<b>drag</b>()
 
 Constructs a new drag behavior. Once constructed, you can apply the drag behavior to selected elements using selection.call:
 
@@ -19,7 +19,7 @@ All registered listeners use the “drag” namespace, so to subsequently remove
 selection.on(".drag", null);
 ```
 
-<a name="on" href="Drag-Behavior#on">#</a> drag.<b>on</b>(<i>type</i>[, <i>listener</i>])
+<a name="on" href="Drag-Behavior.md#on">#</a> drag.<b>on</b>(<i>type</i>[, <i>listener</i>])
 
 Registers the specified *listener* to receive events of the specified *type* from the drag behavior. If no *listener* is specified, returns the currently-registered listener for the specified event *type*. (The *type* may include a namespace; see [dispatch.on](Internals.md#dispatch_on) for additional details.) The following events are supported:
 
@@ -46,7 +46,7 @@ drag.on("dragstart", function() {
 });
 ```
 
-<a name="origin" href="Drag-Behavior#origin">#</a> drag.<b>origin</b>([<i>origin</i>])
+<a name="origin" href="Drag-Behavior.md#origin">#</a> drag.<b>origin</b>([<i>origin</i>])
 
 If *origin* is specified, sets the origin accessor to the specified function. If *origin* is not specified, returns the current origin accessor which defaults to null.
 

--- a/Force-Layout.md
+++ b/Force-Layout.md
@@ -21,7 +21,7 @@ Some fun examples:
 
 Like other classes in D3, layouts follow the method chaining pattern where setter methods return the layout itself, allowing multiple setters to be invoked in a concise statement. Unlike some of the other layout implementations which are stateless, the force layout keeps a reference to the associated nodes and links internally; thus, a given force layout instance can only be used with a single dataset.
 
-<a name="force" href="Force-Layout#force">#</a> d3.layout.<b>force</b>()
+<a name="force" href="Force-Layout.md#force">#</a> d3.layout.<b>force</b>()
 
 Constructs a new force-directed layout with the default settings: size 1×1, link strength 1, friction 0.9, distance 20, charge strength -30, gravity strength 0.1, and theta parameter 0.8. The default nodes and links are the empty array, and when the layout is started, the internal alpha cooling parameter is set to 0.1. The general pattern for constructing force-directed layouts is to set all the configuration properties, and then call [start](Force-Layout.md#start):
 
@@ -42,25 +42,25 @@ var force = d3.layout.force()
 
 Note that, like D3's other layouts, the force-directed layout doesn't mandate a particular visual representation. Most commonly, nodes are mapped to SVG circle elements, and links are mapped to SVG line elements. But you might also display nodes as [symbols](http://bl.ocks.org/mbostock/1062383) or [images](http://bl.ocks.org/mbostock/950642).
 
-<a name="size" href="Force-Layout#size">#</a> force.<b>size</b>([<i>width, height</i>])
+<a name="size" href="Force-Layout.md#size">#</a> force.<b>size</b>([<i>width, height</i>])
 
 If *size* is specified, sets the available layout size to the specified two-element array of numbers representing *x* and *y*. If *size* is not specified, returns the current size, which defaults to [1, 1]. The size affects two aspects of the force-directed layout: the gravitational center, and the initial random position. The center of gravity is simply [ *x* / 2, *y* / 2 ]. When nodes are added to the force layout, if they do not have *x* and *y* attributes already set, then these attributes are initialized using a uniform random distribution in the range [0, *x*] and [0, *y*], respectively.
 
-<a name="linkDistance" href="Force-Layout#linkDistance">#</a> force.<b>linkDistance</b>([<i>distance</i>])
+<a name="linkDistance" href="Force-Layout.md#linkDistance">#</a> force.<b>linkDistance</b>([<i>distance</i>])
 
 If *distance* is specified, sets the target distance between linked nodes to the specified value. If *distance* is not specified, returns the layout's current link distance, which defaults to 20. If *distance* is a constant, then all links are the same distance. Otherwise, if *distance* is a function, then the function is evaluated for each link (in order), being passed the link and its index, with the `this` context as the force layout; the function's return value is then used to set each link's distance. The function is evaluated whenever the layout [starts](Force-Layout.md#start).
 
 Links are not implemented as "spring forces", as is common in other force-directed layouts, but as weak geometric constraints. For each tick of the layout, the distance between each pair of linked nodes is computed and compared to the target distance; the links are then moved towards each other, or away from each other, so as to converge on the desired distance. This method of constraints relaxation on top of position Verlet integration is vastly more stable than previous methods using spring forces, and also allows for the flexible implementation of [other constraints](http://www.csse.monash.edu.au/~tdwyer/Dwyer2009FastConstraints.pdf) in the tick event listener, such as hierarchical layering.
 
-<a name="linkStrength" href="Force-Layout#linkStrength">#</a> force.<b>linkStrength</b>([<i>strength</i>])
+<a name="linkStrength" href="Force-Layout.md#linkStrength">#</a> force.<b>linkStrength</b>([<i>strength</i>])
 
 If *strength* is specified, sets the strength (rigidity) of links to the specified value in the range [0,1]. If *strength* is not specified, returns the layout's current link strength, which defaults to 1. If *strength* is a constant, then all links have the same strength. Otherwise, if *strength* is a function, then the function is evaluated for each link (in order), being passed the link and its index, with the `this` context as the force layout; the function's return value is then used to set each link's strength. The function is evaluated whenever the layout [starts](Force-Layout.md#start).
 
-<a name="friction" href="Force-Layout#friction">#</a> force.<b>friction</b>([<i>friction</i>])
+<a name="friction" href="Force-Layout.md#friction">#</a> force.<b>friction</b>([<i>friction</i>])
 
 If *friction* is specified, sets the friction coefficient to the specified value. If *friction* is not specified, returns the current coefficient, which defaults to 0.9. The name of this parameter is perhaps misleading; it does not correspond to a standard physical [coefficient of friction](http://en.wikipedia.org/wiki/Friction#Coefficient_of_friction). Instead, it more closely approximates velocity decay: at each tick of the simulation, the particle velocity is scaled by the specified *friction*. Thus, a value of 1 corresponds to a frictionless environment, while a value of 0 freezes all particles in place. Values outside the range [0,1] are not recommended and may have destabilizing effects.
 
-<a name="charge" href="Force-Layout#charge">#</a> force.<b>charge</b>([<i>charge</i>])
+<a name="charge" href="Force-Layout.md#charge">#</a> force.<b>charge</b>([<i>charge</i>])
 
 If *charge* is specified, sets the charge strength to the specified value. If *charge* is not specified, returns the current charge strength, which defaults to -30. If *charge* is a constant, then all nodes have the same charge. Otherwise, if *charge* is a function, then the function is evaluated for each node (in order), being passed the node and its index, with the `this` context as the force layout; the function's return value is then used to set each node's charge. The function is evaluated whenever the layout [starts](Force-Layout.md#start).
 
@@ -70,19 +70,19 @@ A negative value results in node repulsion, while a positive value results in no
 
 If *distance* is specified, sets the maximum distance over which charge forces are applied. If *distance* is not specified, returns the current maximum charge distance, which defaults to infinity. Specifying a finite charge distance improves the performance of the force layout and produces a more localized layout; distance-limited charge forces are especially useful in conjunction with custom gravity. For an example, see [“Constellations of Directors and their Stars”](http://www.nytimes.com/newsgraphics/2013/09/07/director-star-chart/) (_The New York Times_).
 
-<a name="theta" href="Force-Layout#theta">#</a> force.<b>theta</b>([<i>theta</i>])
+<a name="theta" href="Force-Layout.md#theta">#</a> force.<b>theta</b>([<i>theta</i>])
 
 If *theta* is specified, sets the Barnes–Hut approximation criterion to the specified value. If *theta* is not specified, returns the current value, which defaults to 0.8.  Unlike links, which only affect two linked nodes, the charge force is global: every node affects every other node, even if they are on disconnected subgraphs.
 
 To avoid quadratic performance slowdown for large graphs, the force layout uses the [Barnes–Hut approximation](http://en.wikipedia.org/wiki/Barnes-Hut_simulation) which takes O(*n* log *n*) per tick. For each tick, a quadtree is created to store the current node positions; then for each node, the sum charge force of all other nodes on the given node are computed. For clusters of nodes that are far away, the charge force is approximated by treating the distance cluster of nodes as a single, larger node. *Theta* determines the accuracy of the computation: if the ratio of the area of a quadrant in the quadtree to the distance between a node to the quadrant's center of mass is less than *theta*, all nodes in the given quadrant are treated as a single, larger node rather than computed individually.
 
-<a name="gravity" href="Force-Layout#gravity">#</a> force.<b>gravity</b>([<i>gravity</i>])
+<a name="gravity" href="Force-Layout.md#gravity">#</a> force.<b>gravity</b>([<i>gravity</i>])
 
 If *gravity* is specified, sets the gravitational strength to the specified numerical value. If *gravity* is not specified, returns the current gravitational strength, which defaults to 0.1. The name of this parameter is perhaps misleading; it does not correspond to physical [gravity](http://en.wikipedia.org/wiki/Gravitation) (which can be simulated using a positive [charge](Force-Layout.md#charge) parameter). Instead, gravity is implemented as a weak geometric constraint similar to a virtual spring connecting each node to the center of the layout's [size](Force-Layout.md#size). This approach has nice properties: near the center of the layout, the gravitational strength is almost zero, avoiding any local distortion of the layout; as nodes get pushed farther away from the center, the gravitational strength becomes stronger in linear proportion to the distance. Thus, gravity will always overcome repulsive charge forces at some threshold, preventing disconnected nodes from escaping the layout.
 
 Gravity can be disabled by setting the gravitational strength to zero. If you disable gravity, it is recommended that you implement some other geometric constraint to prevent nodes from escaping the layout, such as constraining them within the layout's bounds.
 
-<a name="nodes" href="Force-Layout#nodes">#</a> force.<b>nodes</b>([<i>nodes</i>])
+<a name="nodes" href="Force-Layout.md#nodes">#</a> force.<b>nodes</b>([<i>nodes</i>])
 
 If *nodes* is specified, sets the layout's associated nodes to the specified array. If *nodes* is not specified, returns the current array, which defaults to the empty array. Each node has the following attributes:
 
@@ -96,7 +96,7 @@ If *nodes* is specified, sets the layout's associated nodes to the specified arr
 
 These attributes do not need to be set before passing the nodes to the layout; if they are not set, suitable defaults will be initialized by the layout when [start](Force-Layout.md#start) is called. However, be aware that if you are storing other data on your nodes, your data attributes should not conflict with the above properties used by the layout.
 
-<a name="links" href="Force-Layout#links">#</a> force.<b>links</b>([<i>links</i>])
+<a name="links" href="Force-Layout.md#links">#</a> force.<b>links</b>([<i>links</i>])
 
 If *links* is specified, sets the layout's associated links to the specified array. If *links* is not specified, returns the current array, which defaults to the empty array. Each link has the following attributes:
 
@@ -105,7 +105,7 @@ If *links* is specified, sets the layout's associated links to the specified arr
 
 Note: the values of the source and target attributes may be initially specified as indexes into the *nodes* array; these will be replaced by references after the call to [start](#start). Link objects may have additional fields that you specify; this data can be used to compute link [strength](Force-Layout.md#linkStrength) and [distance](Force-Layout.md#linkDistance) on a per-link basis using an accessor function.
 
-<a name="start" href="Force-Layout#start">#</a> force.<b>start</b>()
+<a name="start" href="Force-Layout.md#start">#</a> force.<b>start</b>()
 
 Starts the simulation; this method must be called when the layout is first created, after assigning the nodes and links. In addition, it should be called again whenever the nodes or links change. Internally, the layout uses a cooling parameter *alpha* which controls the layout temperature: as the physical simulation converges on a stable layout, the temperature drops, causing nodes to move more slowly. Eventually, *alpha* drops below a threshold and the simulation stops completely, freeing the CPU and avoiding battery drain. The layout can be reheated using [resume](Force-Layout.md#resume) or by restarting; this happens automatically when using the [drag](Force-Layout.md#drag) behavior.
 
@@ -117,7 +117,7 @@ The layout also initializes the *source* and *target* attributes on the associat
 
 Gets or sets the force layout's cooling parameter, *alpha*. If *value* is specified, sets alpha to the specified value and returns the force layout. If *value* is greater than zero, this method also restarts the force layout if it is not already running, dispatching a "start" event and enabling the tick timer. If *value* is nonpositive, and the force layout is running, this method stops the force layout on the next tick and dispatches an "end" event. If *value* is not specified, this method returns the current alpha value.
 
-<a name="resume" href="Force-Layout#resume">#</a> force.<b>resume</b>()
+<a name="resume" href="Force-Layout.md#resume">#</a> force.<b>resume</b>()
 
 Equivalent to:
 
@@ -127,7 +127,7 @@ force.alpha(.1);
 
 Sets the cooling parameter *alpha* to 0.1. This method sets the internal *alpha* parameter to 0.1, and then restarts the [timer](Transitions.md#d3_timer). Typically, you don't need to call this method directly; it is called automatically by [start](Force-Layout.md#start). It is also called automatically by [drag](Force-Layout.md#drag) during a drag gesture.
 
-<a name="stop" href="Force-Layout#stop">#</a> force.<b>stop</b>()
+<a name="stop" href="Force-Layout.md#stop">#</a> force.<b>stop</b>()
 
 Equivalent to:
 
@@ -158,7 +158,7 @@ nodes.forEach(function(d, i) {
 
 If you do not initialize the positions manually, the force layout will initialize them randomly, resulting in somewhat unpredictable behavior.
 
-<a name="on" href="Force-Layout#on">#</a> force.<b>on</b>(<i>type</i>, <i>listener</i>)
+<a name="on" href="Force-Layout.md#on">#</a> force.<b>on</b>(<i>type</i>, <i>listener</i>)
 
 Registers the specified *listener* to receive events of the specified *type* from the force layout. Currently, only "start", "tick", and "end" events are supported.
 
@@ -197,7 +197,7 @@ In this case, we've stored the selections `node` and `link` on initialization, s
 
 The "end" event is dispatched when the simulations internal alpha cooling parameter drops below the the cut-off value (0.005) and is set to zero.
 
-<a name="drag" href="Force-Layout#drag">#</a> force.<b>drag</b>()
+<a name="drag" href="Force-Layout.md#drag">#</a> force.<b>drag</b>()
 
 Bind a behavior to nodes to allow interactive dragging, either using the mouse or touch. Use this in conjunction with the [call](Selections.md#call) operator on the nodes; for example, say `node.call(force.drag)` on initialization. The drag event sets the *fixed* attribute of nodes on mouseover, such that as soon as the mouse is over a node, it stops moving. Fixing on mouseover, rather than on mousedown, makes it easier to catch moving nodes. When a mousedown event is received, and on each subsequent mousemove until mouseup, the node center is set to the current mouse position. In addition, each mousemove triggers a [resume](Force-Layout.md#resume) of the force layout, reheating the simulation. If you want dragged nodes to remain fixed after dragging, set the *fixed* attribute to true on _dragstart_, as in the [sticky force layout](http://bl.ocks.org/mbostock/3750558) example.
 

--- a/Formatting.md
+++ b/Formatting.md
@@ -87,7 +87,7 @@ console.log(prefix.scale(1.21e9)); // 1.21
 
 This method is used by d3.format for the `s` format.
 
-<a name="d3_round" href="Formatting#d3_round">#</a> d3.<b>round</b>(<i>x</i>[, <i>n</i>])
+<a name="d3_round" href="Formatting.md#d3_round">#</a> d3.<b>round</b>(<i>x</i>[, <i>n</i>])
 
 Returns the value *x* rounded to *n* digits after the decimal point. If *n* is omitted, it defaults to zero. The result is a number. Values are rounded to the closest multiple of 10 to the power minus *n*; if two multiples are equally close, the value is rounded up in accordance with the built-in [round](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Math/round) function. For example:
 
@@ -103,7 +103,7 @@ Note that the resulting number when converted to a string may be imprecise due t
 
 ## Strings
 
-<a name="d3_requote" href="Formatting#d3_requote">#</a> d3.<b>requote</b>(<i>string</i>)
+<a name="d3_requote" href="Formatting.md#d3_requote">#</a> d3.<b>requote</b>(<i>string</i>)
 
 Returns a quoted (escaped) version of the specified *string* such that the string may be embedded in a regular expression as a string literal.
 

--- a/Histogram-Layout.md
+++ b/Histogram-Layout.md
@@ -4,11 +4,11 @@
 
 A **histogram layout** shows the distribution of data by grouping discrete data points into bins. See [bl.ock 3048450](http://bl.ocks.org/mbostock/3048450) for example usage.
 
-<a name="histogram" href="Histogram-Layout#histogram">#</a> d3.layout.<b>histogram</b>()
+<a name="histogram" href="Histogram-Layout.md#histogram">#</a> d3.layout.<b>histogram</b>()
 
 Constructs a new histogram function with the default value accessor, range function, and bin function. By default, the histogram function returns frequencies. The returned layout object is both an object and a function. That is: you can call the layout like any other function, and the layout has additional methods that change its behavior. Like other classes in D3, layouts follow the method chaining pattern where setter methods return the layout itself, allowing multiple setters to be invoked in a concise statement.
 
-<a name="_histogram" href="Histogram-Layout#_histogram">#</a> <b>histogram</b>(<i>values</i>[, <i>index</i>])
+<a name="_histogram" href="Histogram-Layout.md#_histogram">#</a> <b>histogram</b>(<i>values</i>[, <i>index</i>])
 
 Evaluates the histogram function on the specified array of *values*. An optional *index* may be specified, which is passed along to the range and bin function. The return value is an array of arrays: each element in the outer array represents a bin, and each bin contains the associated elements from the input *values*. In addition, each bin has three attributes:
 
@@ -18,18 +18,18 @@ Evaluates the histogram function on the specified array of *values*. An optional
 
 Note that the y attribute is the same as the length attribute, in frequency mode.
 
-<a name="value" href="Histogram-Layout#value">#</a> histogram.<b>value</b>([<i>accessor</i>])
+<a name="value" href="Histogram-Layout.md#value">#</a> histogram.<b>value</b>([<i>accessor</i>])
 
 Specifies how to extract a value from the associated data; *accessor* is a function which is invoked on each input value passed to [histogram](Histogram-Layout.md#_histogram), equivalent to calling *values.map(accessor)* before computing the histogram. The default value function is the built-in [Number](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Number), which is similar to the identity function. If *accessor* is not specified, returns the current value accessor.
 
-<a name="range" href="Histogram-Layout#range">#</a> histogram.<b>range</b>([<i>range</i>])
+<a name="range" href="Histogram-Layout.md#range">#</a> histogram.<b>range</b>([<i>range</i>])
 
 Specifies the range of the histogram. Values outside the specified range will be ignored. The *range* may be specified either as a two-element array representing the minimum and maximum value of the range, or as a function that returns the range given the array of *values* and the current *index* passed to [histogram](Histogram-Layout.md#_histogram). The default range is the extent ([minimum](Arrays.md#d3_min) and [maximum](Arrays.md#d3_max)) of the values. If *range* is not specified, returns the current range function.
 
-<a name="bins" href="Histogram-Layout#bins">#</a> histogram.<b>bins</b>()
-<br><a name="bins" href="Histogram-Layout#bins">#</a> histogram.<b>bins</b>(<i>count</i>)
-<br><a name="bins" href="Histogram-Layout#bins">#</a> histogram.<b>bins</b>(<i>thresholds</i>)
-<br><a name="bins" href="Histogram-Layout#bins">#</a> histogram.<b>bins</b>(<i>function</i>)
+<a name="bins" href="Histogram-Layout.md#bins">#</a> histogram.<b>bins</b>()
+<br><a name="bins" href="Histogram-Layout.md#bins">#</a> histogram.<b>bins</b>(<i>count</i>)
+<br><a name="bins" href="Histogram-Layout.md#bins">#</a> histogram.<b>bins</b>(<i>thresholds</i>)
+<br><a name="bins" href="Histogram-Layout.md#bins">#</a> histogram.<b>bins</b>(<i>function</i>)
 
 Specifies how to bin values in the histogram. If no argument is specified, the current binning function is returned, which defaults to an implementation of [Sturges' formula](http://en.wikipedia.org/wiki/Histogram) that divides values into bins using uniformly-spaced values. If a *count* is specified, the value [range](#range) is divided evenly into the specified number of bins.
 
@@ -37,6 +37,6 @@ If an array of *thresholds* is specified, it defines the value thresholds used t
 
 Lastly, if a binning *function* is specified, it is invoked when the layout is passed data, being passed the current [range](Histogram-Layout.md#range), the array of values and the current index passed to [histogram](Histogram-Layout.md#_histogram). This function must then return an array of *thresholds* as described in the previous paragraph.
 
-<a name="frequency" href="Histogram-Layout#frequency">#</a> histogram.<b>frequency</b>([<i>frequency</i>])
+<a name="frequency" href="Histogram-Layout.md#frequency">#</a> histogram.<b>frequency</b>([<i>frequency</i>])
 
 Specifies the meaning of the generated bins’ *y*-values. If *frequency* is true, which is the default, the *y*-value represents the count of elements in the bin. If false, it represents the probability of a random element in the sample population being in that bin. Note that this is a *probability*, not a *probability density*, and so for [irregular histograms](http://bl.ocks.org/mbostock/1624660), you must normalize the *y*-value by the bin width (`bin.y / bin.dx`) for the area of the displayed bar to be proportional to the probability. If *frequency* is not specified, returns the current frequency boolean.

--- a/Hull-Geom.md
+++ b/Hull-Geom.md
@@ -2,19 +2,19 @@
 
 **The [D3 4.0 API Reference](https://github.com/d3/d3/blob/master/API.md) has moved. This page describes the D3 3.x API.**
 
-<a name="hull" href="Hull-Geom#hull">#</a> d3.geom.<b>hull</b>()
+<a name="hull" href="Hull-Geom.md#hull">#</a> d3.geom.<b>hull</b>()
 
 <a href="http://bl.ocks.org/mbostock/4341699"><img src="http://bl.ocks.org/mbostock/raw/4341699/thumbnail.png" width="202"></a>
 
 Create a new hull layout with the default *x*- and *y*-accessors.
 
-<a name="_hull" href="Hull-Geom#_hull">#</a> <b>hull</b>(<i>vertices</i>)
+<a name="_hull" href="Hull-Geom.md#_hull">#</a> <b>hull</b>(<i>vertices</i>)
 
 Returns the convex hull for the specified *vertices* array, using the current x- and y-coordinate accessors. The returned convex hull is represented as an array containing a subset of the input vertices, arranged in counterclockwise order (for consistency with [polygon.clip](Polygon-Geom.md#clip)).
 
 Assumes the *vertices* array is greater than three in length. If *vertices* is of length <= 3, returns [].
 
-<a name="x" href="Hull-Geom#x">#</a> hull.<b>x</b>([<i>x</i>])
+<a name="x" href="Hull-Geom.md#x">#</a> hull.<b>x</b>([<i>x</i>])
 
 If *x* is specified, sets the x-coordinate accessor. If *x* is not specified, returns the current x-coordinate accessor, which defaults to:
 
@@ -22,7 +22,7 @@ If *x* is specified, sets the x-coordinate accessor. If *x* is not specified, re
 function(d) { return d[0]; }
 ```
 
-<a name="y" href="Hull-Geom#y">#</a> hull.<b>y</b>([<i>y</i>])
+<a name="y" href="Hull-Geom.md#y">#</a> hull.<b>y</b>([<i>y</i>])
 
 If *y* is specified, sets the y-coordinate accessor. If *y* is not specified, returns the current y-coordinate accessor, which defaults to:
 

--- a/Internals.md
+++ b/Internals.md
@@ -6,11 +6,11 @@ Various utilities for implementing reusable components.
 
 ## Functions
 
-<a name="functor" href="Internals#functor">#</a> d3.<b>functor</b>(<i>value</i>)
+<a name="functor" href="Internals.md#functor">#</a> d3.<b>functor</b>(<i>value</i>)
 
 If the specified *value* is a function, returns the specified value. Otherwise, returns a function that returns the specified value. This method is used internally as a lazy way of upcasting constant values to functions, in cases where a property may be specified either as a function or a constant. For example, many D3 layouts allow properties to be specified this way, and it simplifies the implementation if we automatically convert constant values to functions.
 
-<a name="rebind" href="Internals#rebind">#</a> d3.<b>rebind</b>(<i>target</i>, <i>source</i>, <i>names…</i>)
+<a name="rebind" href="Internals.md#rebind">#</a> d3.<b>rebind</b>(<i>target</i>, <i>source</i>, <i>names…</i>)
 
 Copies the methods with the specified *names* from *source* to *target*, and returns *target*. Calling one of the named methods on the target object invokes the same-named method on the source object, passing any arguments passed to the target method, and using the source object as the `this` context. If the source method returns the source object, the target method returns the target object (“setter” method); otherwise, the target method returns the return value of the source method (“getter” mode). The rebind operator allows inherited methods (mix-ins) to be rebound to a subclass on a different object.
 
@@ -22,7 +22,7 @@ D3’s behaviors and higher level components, such as the [brush](SVG-Controls.m
 
 For visualizations with coordinated views, d3.dispatch provides a convenient lightweight mechanism for loosely-coupled components. Organizing your code with d3.dispatch can assist with separation of concerns and make your code easier to maintain.
 
-<a name="d3_dispatch" href="Internals#d3_dispatch">#</a> d3.<b>dispatch</b>(<i>types…</i>)
+<a name="d3_dispatch" href="Internals.md#d3_dispatch">#</a> d3.<b>dispatch</b>(<i>types…</i>)
 
 Creates a new dispatcher object for the specified *types*. Each argument is a string representing the name of the event type, such as "zoom" or "change". The returned object is an associative array; each type name is associated with a dispatch object. For example, if you wanted to create an event dispatcher for "start" and "end" events, you can say:
 
@@ -44,7 +44,7 @@ dispatch.start();
 
 For details on how to pass arguments to listeners, see [dispatch](#dispatch).
 
-<a name="dispatch_on" href="Internals#dispatch_on">#</a> dispatch.<b>on</b>(<i>type</i>[, <i>listener</i>])
+<a name="dispatch_on" href="Internals.md#dispatch_on">#</a> dispatch.<b>on</b>(<i>type</i>[, <i>listener</i>])
 
 Adds or removes an event *listener* for the specified *type*. The *type* is a string event type name, such as "start" or "end".  The specified *listener* is invoked with the context and arguments determined by the caller; see [dispatch](#dispatch).
 
@@ -52,7 +52,7 @@ If an event listener was already registered for the same type, the existing list
 
 If *listener* is not specified, returns the currently-assigned listener for the specified *type*, if any.
 
-<a name="dispatch" href="Internals#dispatch">#</a> dispatch.<b>*type*</b>(<i>arguments…</i>)
+<a name="dispatch" href="Internals.md#dispatch">#</a> dispatch.<b>*type*</b>(<i>arguments…</i>)
 
 The *type* method (such as `dispatch.start` in the above example) notifies each registered listener, passing the listener the specified *arguments*. The `this` context will be used as the context of the registered listeners. For example, to invoke all registered listeners with the context *foo* and the argument *bar*, say dispatch.call( *foo*, *bar* ). Thus, you can pass whatever arguments you want to the listeners; most commonly, you might create an object that represents the event, or pass along the current datum ( *d* ) and index ( *i* ). You can also control the "this" context of the listeners using [call](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/Call) or [apply](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/Apply).
 

--- a/Namespaces.md
+++ b/Namespaces.md
@@ -4,7 +4,7 @@
 
 SVG has a different namespace from HTML, so D3 provides a few tools to simplify dealing with namespaces.
 
-<a name="prefix" href="Namespaces#prefix">#</a> d3.ns.<b>prefix</b>
+<a name="prefix" href="Namespaces.md#prefix">#</a> d3.ns.<b>prefix</b>
 
 The map of registered namespace prefixes. The default value is:
 
@@ -20,7 +20,7 @@ The map of registered namespace prefixes. The default value is:
 
 Additional prefixes may be assigned as needed to create elements or attributes in other namespaces.
 
-<a name="qualify" href="Namespaces#qualify">#</a> d3.ns.<b>qualify</b>(<i>name</i>)
+<a name="qualify" href="Namespaces.md#qualify">#</a> d3.ns.<b>qualify</b>(<i>name</i>)
 
 Qualifies the specified *name*, which may have a namespace prefix. If the name contains a colon (":"), the substring before the colon is interpreted as the namespace prefix, which must be registered in d3.ns.**prefix**; the return value is an object with `space` and `local` attributes containing the full namespace URL and the local name. For example, the result of qualify("svg:text") is:
 

--- a/Ordinal-Scales.md
+++ b/Ordinal-Scales.md
@@ -6,29 +6,29 @@
 
 A scale object, such as that returned by [d3.scale.ordinal](Ordinal-Scales.md#ordinal), is both an object and a function. That is: you can call the scale like any other function, and the scale has additional methods that change its behavior. Like other classes in D3, scales follow the method chaining pattern where setter methods return the scale itself, allowing multiple setters to be invoked in a concise statement.
 
-<a name="ordinal" href="Ordinal-Scales#ordinal">#</a> d3.scale.<b>ordinal</b>()
+<a name="ordinal" href="Ordinal-Scales.md#ordinal">#</a> d3.scale.<b>ordinal</b>()
 
 Constructs a new ordinal scale with an empty domain and an empty range. The ordinal scale is invalid (always returning undefined) until an output range is specified.
 
-<a name="_ordinal" href="Ordinal-Scales#_ordinal">#</a> <b>ordinal</b>(<i>x</i>)
+<a name="_ordinal" href="Ordinal-Scales.md#_ordinal">#</a> <b>ordinal</b>(<i>x</i>)
 
 Given a value *x* in the input domain, returns the corresponding value in the output range.
 
 If the range was specified explicitly (as by [range](#ordinal_range), but not [rangeBands](#ordinal_rangeBands), [rangeRoundBands](#ordinal_rangeRoundBands) or [rangePoints](#ordinal_rangePoints)), _and_ the given value *x* is not in the scale’s [domain](#ordinal_domain), then *x* is implicitly added to the domain; subsequent invocations of the scale given the same value *x* will return the same value *y* from the range.
 
-<a name="ordinal_domain" href="Ordinal-Scales#ordinal_domain">#</a> ordinal.<b>domain</b>([<i>values</i>])
+<a name="ordinal_domain" href="Ordinal-Scales.md#ordinal_domain">#</a> ordinal.<b>domain</b>([<i>values</i>])
 
 If *values* is specified, sets the input domain of the ordinal scale to the specified array of values. The first element in *values* will be mapped to the first element in the output range, the second domain value to the second range value, and so on. Domain values are stored internally in an associative array as a mapping from value to index; the resulting index is then used to retrieve a value from the output range. Thus, an ordinal scale's values must be coercible to a string, and the stringified version of the domain value uniquely identifies the corresponding range value. If *values* is not specified, this method returns the current domain.
 
 Setting the domain on an ordinal scale is optional. If no domain is set, a [range](#ordinal_range) must be set explicitly. Then, each unique value that is passed to the scale function will be assigned a new value from the output range; in other words, the domain will be inferred implicitly from usage. Although domains may thus be constructed implicitly, it is still a good idea to assign the ordinal scale's domain explicitly to ensure deterministic behavior, as inferring the domain from usage will be dependent on ordering.
 
-<a name="ordinal_range" href="Ordinal-Scales#ordinal_range">#</a> ordinal.<b>range</b>([<i>values</i>])
+<a name="ordinal_range" href="Ordinal-Scales.md#ordinal_range">#</a> ordinal.<b>range</b>([<i>values</i>])
 
 If *values* is specified, sets the output range of the ordinal scale to the specified array of values. The first element in the domain will be mapped to the first element in *values*, the second domain value to the second range value, and so on. If there are fewer elements in the range than in the domain, the scale will recycle values from the start of the range. If *values* is not specified, this method returns the current output range.
 
 This method is intended for when the set of discrete output values is computed explicitly, such as a set of categorical colors. In other cases, such as determining the layout of an ordinal scatterplot or bar chart, you may find the [rangePoints](Ordinal-Scales.md#ordinal_rangePoints) or [rangeBands](Ordinal-Scales.md#ordinal_rangeBands) operators more convenient.
 
-<a name="ordinal_rangePoints" href="Ordinal-Scales#ordinal_rangePoints">#</a> ordinal.<b>rangePoints</b>(<i>interval</i>[, <i>padding</i>])
+<a name="ordinal_rangePoints" href="Ordinal-Scales.md#ordinal_rangePoints">#</a> ordinal.<b>rangePoints</b>(<i>interval</i>[, <i>padding</i>])
 
 Sets the output range from the specified continuous *interval*. The array *interval* contains two elements representing the minimum and maximum numeric value. This interval is subdivided into *n* evenly-spaced **points**, where *n* is the number of (unique) values in the input domain. The first and last point may be offset from the edge of the interval according to the specified *padding*, which defaults to zero. The *padding* is expressed as a multiple of the spacing between points. A reasonable value is 1.0, such that the first and last point will be offset from the minimum and maximum value by half the distance between points.
 
@@ -68,7 +68,7 @@ o.range(); // [1, 3, 5, …, 95, 97, 98]
 
 (Alternatively, you could round the output of the scale manually or apply shape-rendering: crispEdges. However, this will result in irregularly spaced points.)
 
-<a name="ordinal_rangeBands" href="Ordinal-Scales#ordinal_rangeBands">#</a> ordinal.<b>rangeBands</b>(<i>interval</i>[, <i>padding</i>[, <i>outerPadding</i>]])
+<a name="ordinal_rangeBands" href="Ordinal-Scales.md#ordinal_rangeBands">#</a> ordinal.<b>rangeBands</b>(<i>interval</i>[, <i>padding</i>[, <i>outerPadding</i>]])
 
 Sets the output range from the specified continuous *interval*. The array *interval* contains two elements representing the minimum and maximum numeric value. This interval is subdivided into *n* evenly-spaced **bands**, where *n* is the number of (unique) values in the input domain. The bands may be offset from the edge of the interval and other bands according to the specified *padding*, which defaults to zero. The padding is typically in the range [0,1] and corresponds to the amount of space in the range interval to allocate to padding. A value of 0.5 means that the band width will be equal to the padding width. The *outerPadding* argument is for the entire group of bands; a value of 0 means there will be padding only between rangeBands.
 
@@ -84,7 +84,7 @@ o.range(); // [0, 33.333333333333336, 66.66666666666667]
 o.rangeExtent(); // [0, 100]
 ```
 
-<a name="ordinal_rangeRoundBands" href="Ordinal-Scales#ordinal_rangeRoundBands">#</a> ordinal.<b>rangeRoundBands</b>(<i>interval</i>[, <i>padding</i>[, <i>outerPadding</i>]])
+<a name="ordinal_rangeRoundBands" href="Ordinal-Scales.md#ordinal_rangeRoundBands">#</a> ordinal.<b>rangeRoundBands</b>(<i>interval</i>[, <i>padding</i>[, <i>outerPadding</i>]])
 
 Like [rangeBands](Ordinal-Scales.md#ordinal_rangeBands), except guarantees that range values and band width are integers so as to avoid antialiasing artifacts.
 
@@ -113,11 +113,11 @@ o.range(); // [0, 2, 4, …, 94, 96, 98]
 
 (Alternatively, you could round the output of the scale manually or apply shape-rendering: crispEdges. However, this will result in irregularly spaced and sized bands.)
 
-<a name="ordinal_rangeBand" href="Ordinal-Scales#ordinal_rangeBand">#</a> ordinal.<b>rangeBand</b>()
+<a name="ordinal_rangeBand" href="Ordinal-Scales.md#ordinal_rangeBand">#</a> ordinal.<b>rangeBand</b>()
 
 Returns the band width. When the scale’s range is configured with rangeBands or rangeRoundBands, the scale returns the lower value for the given input. The upper value can then be computed by offsetting by the band width. If the scale’s range is set using range or rangePoints, the band width is zero.
 
-<a name="ordinal_rangeExtent" href="Ordinal-Scales#ordinal_rangeExtent">#</a> ordinal.<b>rangeExtent</b>()
+<a name="ordinal_rangeExtent" href="Ordinal-Scales.md#ordinal_rangeExtent">#</a> ordinal.<b>rangeExtent</b>()
 
 Returns a two-element array representing the extent of the scale's range, i.e., the smallest and largest values.
 
@@ -127,7 +127,7 @@ Returns an exact copy of this ordinal scale. Changes to this scale will not affe
 
 ## Categorical Colors
 
-<a name="category10" href="Ordinal-Scales#category10">#</a> d3.scale.<b>category10</b>()
+<a name="category10" href="Ordinal-Scales.md#category10">#</a> d3.scale.<b>category10</b>()
 
 Constructs a new ordinal scale with a range of ten categorical colors:
 
@@ -142,7 +142,7 @@ Constructs a new ordinal scale with a range of ten categorical colors:
 ![bcbd22](img/bcbd22.png) #bcbd22<br>
 ![17becf](img/17becf.png) #17becf<br>
 
-<a name="category20" href="Ordinal-Scales#category20">#</a> d3.scale.<b>category20</b>()
+<a name="category20" href="Ordinal-Scales.md#category20">#</a> d3.scale.<b>category20</b>()
 
 Constructs a new ordinal scale with a range of twenty categorical colors:
 
@@ -167,7 +167,7 @@ Constructs a new ordinal scale with a range of twenty categorical colors:
 ![17becf](img/17becf.png) #17becf<br>
 ![9edae5](img/9edae5.png) #9edae5<br>
 
-<a name="category20b" href="Ordinal-Scales#category20b">#</a> d3.scale.<b>category20b</b>()
+<a name="category20b" href="Ordinal-Scales.md#category20b">#</a> d3.scale.<b>category20b</b>()
 
 Constructs a new ordinal scale with a range of twenty categorical colors:
 
@@ -192,7 +192,7 @@ Constructs a new ordinal scale with a range of twenty categorical colors:
 ![ce6dbd](img/ce6dbd.png) #ce6dbd<br>
 ![de9ed6](img/de9ed6.png) #de9ed6<br>
 
-<a name="category20c" href="Ordinal-Scales#category20c">#</a> d3.scale.<b>category20c</b>()
+<a name="category20c" href="Ordinal-Scales.md#category20c">#</a> d3.scale.<b>category20c</b>()
 
 Constructs a new ordinal scale with a range of twenty categorical colors:
 

--- a/Polygon-Geom.md
+++ b/Polygon-Geom.md
@@ -2,18 +2,18 @@
 
 **The [D3 4.0 API Reference](https://github.com/d3/d3/blob/master/API.md) has moved. This page describes the D3 3.x API.**
 
-<a name="polygon" href="Polygon-Geom#polygon">#</a> d3.geom.<b>polygon</b>(<i>vertices</i>)
+<a name="polygon" href="Polygon-Geom.md#polygon">#</a> d3.geom.<b>polygon</b>(<i>vertices</i>)
 
 Returns the input array of vertices with additional methods attached, as described below.
 
-<a name="area" href="Polygon-Geom#area">#</a> polygon.<b>area</b>()
+<a name="area" href="Polygon-Geom.md#area">#</a> polygon.<b>area</b>()
 
 Returns the signed area of this polygon. If the vertices are in counterclockwise order, the area is positive, otherwise it is negative.
 
-<a name="centroid" href="Polygon-Geom#centroid">#</a> polygon.<b>centroid</b>()
+<a name="centroid" href="Polygon-Geom.md#centroid">#</a> polygon.<b>centroid</b>()
 
 Returns a two-element array representing the centroid of this polygon.
 
-<a name="clip" href="Polygon-Geom#clip">#</a> polygon.<b>clip</b>(<i>subject</i>)
+<a name="clip" href="Polygon-Geom.md#clip">#</a> polygon.<b>clip</b>(<i>subject</i>)
 
 Clips the *subject* polygon against this polygon. In other words, returns a polygon representing the intersection of this polygon and the *subject* polygon. Assumes the clip polygon is counterclockwise and convex.

--- a/Quadtree-Geom.md
+++ b/Quadtree-Geom.md
@@ -14,9 +14,9 @@ A **quadtree** is a two-dimensional recursive spatial subdivision. This implemen
 
 Creates a new quadtree factory with the default [_x_-accessor](#x), [_y_-accessor](#y) and [extent](#extent). The [returned function](#_quadtree) can be used to create any number of quadtrees from data with the factory’s configuration.
 
-<a name="_quadtree" href="Quadtree-Geom#_quadtree">#</a> <b>quadtree</b>(<i>points</i>),
-<a name="_quadtree" href="Quadtree-Geom#_quadtree">#</a> <b>quadtree</b>(<i>points</i>, <i>x2</i>, <i>y2</i>),
-<a name="_quadtree" href="Quadtree-Geom#_quadtree">#</a> <b>quadtree</b>(<i>points</i>, <i>x1</i>, <i>y1</i>, <i>x2</i>, <i>y2</i>)
+<a name="_quadtree" href="Quadtree-Geom.md#_quadtree">#</a> <b>quadtree</b>(<i>points</i>),
+<a name="_quadtree" href="Quadtree-Geom.md#_quadtree">#</a> <b>quadtree</b>(<i>points</i>, <i>x2</i>, <i>y2</i>),
+<a name="_quadtree" href="Quadtree-Geom.md#_quadtree">#</a> <b>quadtree</b>(<i>points</i>, <i>x1</i>, <i>y1</i>, <i>x2</i>, <i>y2</i>)
 
 
 Constructs a new quadtree for the specified array of data _points_, returning the root node of a new quadtree. The elements of the _points_ array must have _x_ and _y_ members defining their coordinates. The current [_x_-](#x) and [_y_-](#y) accessor functions are ignored. The extent can also be specified with by additional, optional arguments with `x1` and `y1` specified explicitly or assumed to be zero if omitted. To build a quadtree by adding points incrementally, the specified _points_ array can be empty, and then points can be later [added](#add) to the returned root node; in this case, you must also specify the [extent](#extent) of the quadtree.

--- a/Quantitative-Scales.md
+++ b/Quantitative-Scales.md
@@ -12,23 +12,23 @@ Linear scales are the most common scale, and a good default choice to map a cont
 
 The state dimensions are [domain](#linear_domain), [range](#linear_range), [output interpolator](#linear_interpolate) and [clamping behavior](#linear_clamp).
 
-<a name="linear" href="Quantitative-Scales#linear">#</a> d3.scale.<b>linear</b>()
+<a name="linear" href="Quantitative-Scales.md#linear">#</a> d3.scale.<b>linear</b>()
 
 Constructs a new linear scale with the default domain [0,1] and the default range [0,1]. Thus, the default linear scale is equivalent to the identity function for numbers; for example linear(0.5) returns 0.5.
 
-<a name="_linear" href="Quantitative-Scales#_linear">#</a> <b>linear</b>(<i>x</i>)
+<a name="_linear" href="Quantitative-Scales.md#_linear">#</a> <b>linear</b>(<i>x</i>)
 
 Given a value *x* in the input domain, returns the corresponding value in the output range.
 
 Note: some [interpolators](#linear_interpolate) **reuse return values**. For example, if the domain values are arbitrary objects, then [d3.interpolateObject](Transitions.md#d3_interpolateObject) is automatically applied and the scale reuses the returned object. Often, the return value of a scale is immediately used to set an [attribute](Selections.md#attr) or [style](Selections.md#style), and you don’t have to worry about this; however, if you need to store the scale’s return value, use string coercion or create a copy as appropriate.
 
-<a name="linear_invert" href="Quantitative-Scales#linear_invert">#</a> linear.<b>invert</b>(<i>y</i>)
+<a name="linear_invert" href="Quantitative-Scales.md#linear_invert">#</a> linear.<b>invert</b>(<i>y</i>)
 
 Returns the value in the input domain *x* for the corresponding value in the output range *y*. This represents the inverse mapping from range to domain. For a valid value *y* in the output range, linear(linear.invert(<i>y</i>)) equals *y*; similarly, for a valid value *x* in the input domain, linear.invert(linear(<i>x</i>)) equals *x*. Equivalently, you can construct the invert operator by building a new scale while swapping the domain and range. The invert operator is particularly useful for interaction, say to determine the value in the input domain that corresponds to the pixel location under the mouse.
 
 Note: the invert operator is only supported if the output range is numeric! D3 allows the output range to be any type; under the hood, [d3.interpolate](Transitions.md#d3_interpolate) or a custom interpolator of your choice is used to map the normalized parameter *t* to a value in the output range. Thus, the output range may be colors, strings, or even arbitrary objects. As there is no facility to "uninterpolate" arbitrary types, the invert operator is currently supported only on numeric ranges.
 
-<a name="linear_domain" href="Quantitative-Scales#linear_domain">#</a> linear.<b>domain</b>([<i>numbers</i>])
+<a name="linear_domain" href="Quantitative-Scales.md#linear_domain">#</a> linear.<b>domain</b>([<i>numbers</i>])
 
 If *numbers* is specified, sets the scale's input domain to the specified array of numbers. The array must contain two or more numbers. If the elements in the given array are not numbers, they will be coerced to numbers; this coercion happens similarly when the scale is called. Thus, a linear scale can be used to encode types such as [date objects](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date) that can be converted to numbers; however, it is often more convenient to use [d3.time.scale](Time-Scales.md) for dates. (You can implement your own convertible number objects using [valueOf](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/valueOf).) If *numbers* is not specified, returns the scale's current input domain.
 
@@ -42,33 +42,33 @@ var color = d3.scale.linear()
 
 The resulting value of color(-.5) is rgb(255, 128, 128), and the value of color(.5) is rgb(128, 192, 128). Internally, polylinear scales perform a binary search for the output interpolator corresponding to the given domain value. By repeating values in both the domain and range, you can also force a chunk of the input domain to map to a constant in the output range.
 
-<a name="linear_range" href="Quantitative-Scales#linear_range">#</a> linear.<b>range</b>([<i>values</i>])
+<a name="linear_range" href="Quantitative-Scales.md#linear_range">#</a> linear.<b>range</b>([<i>values</i>])
 
 If *values* is specified, sets the scale's output range to the specified array of values. The array must contain two or more values, to match the cardinality of the input domain, otherwise the longer of the two is truncated to match the other. The elements in the given array need not be numbers; any value that is supported by the underlying [interpolator](Quantitative-Scales.md#linear_interpolate) will work. However, numeric ranges are required for the invert operator. If *values* is not specified, returns the scale's current output range.
 
-<a name="linear_rangeRound" href="Quantitative-Scales#linear_rangeRound">#</a> linear.<b>rangeRound</b>(<i>values</i>)
+<a name="linear_rangeRound" href="Quantitative-Scales.md#linear_rangeRound">#</a> linear.<b>rangeRound</b>(<i>values</i>)
 
 Sets the scale's output range to the specified array of values, while also setting the scale's interpolator to [d3.interpolateRound](Transitions.md#d3_interpolateRound). This is a convenience routine for when the values output by the scale should be exact integers, such as to avoid antialiasing artifacts. It is also possible to round the output values manually after the scale is applied.
 
-<a name="linear_interpolate" href="Quantitative-Scales#linear_interpolate">#</a> linear.<b>interpolate</b>([<i>factory</i>])
+<a name="linear_interpolate" href="Quantitative-Scales.md#linear_interpolate">#</a> linear.<b>interpolate</b>([<i>factory</i>])
 
 If *factory* is specified, sets the scale's output interpolator using the specified *factory*. The interpolator factory defaults to [d3.interpolate](Transitions.md#d3_interpolate), and is used to map the normalized domain parameter *t* in [0,1] to the corresponding value in the output range. The interpolator factory will be used to construct interpolators for each adjacent pair of values from the output range. If *factory* is not specified, returns the scale's interpolator factory.
 
-<a name="linear_clamp" href="Quantitative-Scales#linear_clamp">#</a> linear.<b>clamp</b>([<i>boolean</i>])
+<a name="linear_clamp" href="Quantitative-Scales.md#linear_clamp">#</a> linear.<b>clamp</b>([<i>boolean</i>])
 
 If *boolean* is specified, enables or disables clamping accordingly. By default, clamping is disabled, such that if a value outside the input domain is passed to the scale, the scale may return a value outside the output range through linear extrapolation. For example, with the default domain and range of [0,1], an input value of 2 will return an output value of 2. If clamping is enabled, the normalized domain parameter *t* is clamped to the range [0,1], such that the return value of the scale is always within the scale's output range. If *boolean* is not specified, returns whether or not the scale currently clamps values to within the output range.
 
-<a name="linear_nice" href="Quantitative-Scales#linear_nice">#</a> linear.<b>nice</b>([<i>count</i>])
+<a name="linear_nice" href="Quantitative-Scales.md#linear_nice">#</a> linear.<b>nice</b>([<i>count</i>])
 
 Extends the domain so that it starts and ends on nice round values. This method typically modifies the scale's domain, and may only extend the bounds to the nearest round value. The precision of the round value is dependent on the extent of the domain *dx* according to the following formula: exp(round(log(<i>dx</i>)) - 1). Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.20147987687960267, 0.996679553296417], the nice domain is [0.2, 1]. If the domain has more than two values, nicing the domain only affects the first and last value.
 
 The optional tick *count* argument allows greater control over the step size used to extend the bounds, guaranteeing that the returned [ticks](#linear_ticks) will exactly cover the domain.
 
-<a name="linear_ticks" href="Quantitative-Scales#linear_ticks">#</a> linear.<b>ticks</b>([<i>count</i>])
+<a name="linear_ticks" href="Quantitative-Scales.md#linear_ticks">#</a> linear.<b>ticks</b>([<i>count</i>])
 
 A stateless method that returns approximately *count* representative values from the scale's input domain. If *count* is not specified, it defaults to 10. The returned tick values are uniformly spaced, have human-readable values (such as multiples of powers of 10), and are guaranteed to be within the extent of the input domain. Ticks are often used to display reference lines, or tick marks, in conjunction with the visualized data. The specified *count* is only a hint; the scale may return more or fewer values depending on the input domain.
 
-<a name="linear_tickFormat" href="Quantitative-Scales#linear_tickFormat">#</a> linear.<b>tickFormat</b>(<i>count</i>, [<i>format</i>])
+<a name="linear_tickFormat" href="Quantitative-Scales.md#linear_tickFormat">#</a> linear.<b>tickFormat</b>(<i>count</i>, [<i>format</i>])
 
 A stateless method that returns a [number format](Formatting.md#d3_format) function suitable for displaying a tick value. The specified *count* should have the same value as the count that is used to generate the tick values. You don't have to use the scale's built-in tick format, but it automatically computes the appropriate precision based on the fixed interval between tick values.
 
@@ -124,7 +124,7 @@ Returns an exact copy of this scale. Changes to this scale will not affect the r
 
 Power scales are similar to linear scales, except there's an exponential transform that is applied to the input domain value before the output range value is computed. The mapping to the output range value *y* can be expressed as a function of the input domain value *x*: *y* = *mx^k* + *b*, where *k* is the exponent value. Power scales also support negative values, in which case the input value is multiplied by -1, and the resulting output value is also multiplied by -1.
 
-<a name="sqrt" href="Quantitative-Scales#sqrt">#</a> d3.scale.<b>sqrt</b>()
+<a name="sqrt" href="Quantitative-Scales.md#sqrt">#</a> d3.scale.<b>sqrt</b>()
 
 Constructs a new power scale with the default domain [0,1], the default range [0,1], and the exponent .5. This method is shorthand for:
 
@@ -134,59 +134,59 @@ d3.scale.pow().exponent(.5)
 
 The returned scale is a function that takes a single argument *x* representing a value in the input domain; the return value is the corresponding value in the output range. Thus, the returned scale is equivalent to the [sqrt](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Math/sqrt) function for numbers; for example sqrt(0.25) returns 0.5.
 
-<a name="pow" href="Quantitative-Scales#pow">#</a> d3.scale.<b>pow</b>()
+<a name="pow" href="Quantitative-Scales.md#pow">#</a> d3.scale.<b>pow</b>()
 
 Constructs a new power scale with the default domain [0,1], the default range [0,1], and the default exponent 1. Thus, the default power scale is equivalent to the identity function for numbers; for example pow(0.5) returns 0.5.
 
-<a name="_pow" href="Quantitative-Scales#_pow">#</a> <b>pow</b>(<i>x</i>)
+<a name="_pow" href="Quantitative-Scales.md#_pow">#</a> <b>pow</b>(<i>x</i>)
 
 Given a value *x* in the input domain, returns the corresponding value in the output range.
 
 Note: some [interpolators](#pow_interpolate) **reuse return values**. For example, if the domain values are arbitrary objects, then [d3.interpolateObject](Transitions.md#d3_interpolateObject) is automatically applied and the scale reuses the returned object. Often, the return value of a scale is immediately used to set an [attribute](Selections.md#attr) or [style](Selections.md#style), and you don’t have to worry about this; however, if you need to store the scale’s return value, use string coercion or create a copy as appropriate.
 
-<a name="pow_invert" href="Quantitative-Scales#pow_invert">#</a> pow.<b>invert</b>(<i>y</i>)
+<a name="pow_invert" href="Quantitative-Scales.md#pow_invert">#</a> pow.<b>invert</b>(<i>y</i>)
 
 Returns the value in the input domain *x* for the corresponding value in the output range *y*. This represents the inverse mapping from range to domain. For a valid value *y* in the output range, pow(pow.invert(<i>y</i>)) equals *y*; similarly, for a valid value *x* in the input domain, pow.invert(pow(<i>x</i>)) equals *x*. Equivalently, you can construct the invert operator by building a new scale while swapping the domain and range. The invert operator is particularly useful for interaction, say to determine the value in the input domain that corresponds to the pixel location under the mouse.
 
 Note: the invert operator is only supported if the output range is numeric! D3 allows the output range to be any type; under the hood, [d3.interpolate](Transitions.md#d3_interpolate) or a custom interpolator of your choice is used to map the normalized parameter *t* to a value in the output range. Thus, the output range may be colors, strings, or even arbitrary objects. As there is no facility to "uninterpolate" arbitrary types, the invert operator is currently supported only on numeric ranges.
 
-<a name="pow_domain" href="Quantitative-Scales#pow_domain">#</a> pow.<b>domain</b>([<i>numbers</i>])
+<a name="pow_domain" href="Quantitative-Scales.md#pow_domain">#</a> pow.<b>domain</b>([<i>numbers</i>])
 
 If *numbers* is specified, sets the scale's input domain to the specified array of numbers. The array must contain two or more numbers. If the elements in the given array are not numbers, they will be coerced to numbers; this coercion happens similarly when the scale is called. Thus, a power scale can be used to encode any type that can be converted to numbers. If *numbers* is not specified, returns the scale's current input domain.
 
 As with linear scales (see [linear.domain](Quantitative-Scales.md#linear_domain)), power scales can also accept more than two values for the domain and range, thus resulting in polypower scale.
 
-<a name="pow_range" href="Quantitative-Scales#pow_range">#</a> pow.<b>range</b>([<i>values</i>])
+<a name="pow_range" href="Quantitative-Scales.md#pow_range">#</a> pow.<b>range</b>([<i>values</i>])
 
 If *values* is specified, sets the scale's output range to the specified array of values. The array must contain two or more values, to match the cardinality of the input domain, otherwise the longer of the two is truncated to match the other. The elements in the given array need not be numbers; any value that is supported by the underlying [interpolator](Quantitative-Scales.md#pow_interpolate) will work. However, numeric ranges are required for the invert operator. If *values* is not specified, returns the scale's current output range.
 
-<a name="pow_rangeRound" href="Quantitative-Scales#pow_rangeRound">#</a> pow.<b>rangeRound</b>(<i>values</i>)
+<a name="pow_rangeRound" href="Quantitative-Scales.md#pow_rangeRound">#</a> pow.<b>rangeRound</b>(<i>values</i>)
 
 Sets the scale's output range to the specified array of values, while also setting the scale's interpolator to [d3.interpolateRound](Transitions.md#d3_interpolateRound). This is a convenience routine for when the values output by the scale should be exact integers, such as to avoid antialiasing artifacts. It is also possible to round the output values manually after the scale is applied.
 
-<a name="pow_exponent" href="Quantitative-Scales#pow_exponent">#</a> pow.<b>exponent</b>([<i>k</i>])
+<a name="pow_exponent" href="Quantitative-Scales.md#pow_exponent">#</a> pow.<b>exponent</b>([<i>k</i>])
 
 If *k* is specified, sets the current exponent to the given numeric value. If *k* is not specified, returns the current exponent. The default value is 1.
 
-<a name="pow_interpolate" href="Quantitative-Scales#pow_interpolate">#</a> pow.<b>interpolate</b>([<i>factory</i>])
+<a name="pow_interpolate" href="Quantitative-Scales.md#pow_interpolate">#</a> pow.<b>interpolate</b>([<i>factory</i>])
 
 If *factory* is specified, sets the scale's output interpolator using the specified *factory*. The interpolator factory defaults to [d3.interpolate](Transitions.md#d3_interpolate), and is used to map the normalized domain parameter *t* in [0,1] to the corresponding value in the output range. The interpolator factory will be used to construct interpolators for each adjacent pair of values from the output range. If *factory* is not specified, returns the scale's interpolator factory.
 
-<a name="pow_clamp" href="Quantitative-Scales#pow_clamp">#</a> pow.<b>clamp</b>([<i>boolean</i>])
+<a name="pow_clamp" href="Quantitative-Scales.md#pow_clamp">#</a> pow.<b>clamp</b>([<i>boolean</i>])
 
 If *boolean* is specified, enables or disables clamping accordingly. By default, clamping is disabled, such that if a value outside the input domain is passed to the scale, the scale may return a value outside the output range through linear extrapolation. For example, with the default domain and range of [0,1], an input value of 2 will return an output value of 2. If clamping is enabled, the normalized domain parameter *t* is clamped to the range [0,1], such that the return value of the scale is always within the scale's output range. If *boolean* is not specified, returns whether or not the scale currently clamps values to within the output range.
 
-<a name="pow_nice" href="Quantitative-Scales#pow_nice">#</a> pow.<b>nice</b>([<i>m</i>])
+<a name="pow_nice" href="Quantitative-Scales.md#pow_nice">#</a> pow.<b>nice</b>([<i>m</i>])
 
 Extends the domain so that it starts and ends on nice round values. This method typically modifies the scale's domain, and may only extend the bounds to the nearest round value. The precision of the round value is dependent on the extent of the domain *dx* according to the following formula: exp(round(log(<i>dx</i>)) - 1). Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.20147987687960267, 0.996679553296417], the nice domain is [0.2, 1]. If the domain has more than two values, nicing the domain only affects the first and last value.
 
 The optional *m* argument allows a tick count to be specified to control the step size used prior to extending the bounds.
 
-<a name="pow_ticks" href="Quantitative-Scales#pow_ticks">#</a> pow.<b>ticks</b>([<i>count</i>])
+<a name="pow_ticks" href="Quantitative-Scales.md#pow_ticks">#</a> pow.<b>ticks</b>([<i>count</i>])
 
 Returns approximately *count* representative values from the scale's input domain. If *count* is not specified, it defaults to 10. The returned tick values are uniformly spaced, have human-readable values (such as multiples of powers of 10), and are guaranteed to be within the extent of the input domain. Ticks are often used to display reference lines, or tick marks, in conjunction with the visualized data. The specified *count* is only a hint; the scale may return more or fewer values depending on the input domain.
 
-<a name="pow_tickFormat" href="Quantitative-Scales#pow_tickFormat">#</a> pow.<b>tickFormat</b>([<i>count</i>, [<i>format</i>]])
+<a name="pow_tickFormat" href="Quantitative-Scales.md#pow_tickFormat">#</a> pow.<b>tickFormat</b>([<i>count</i>, [<i>format</i>]])
 
 Returns a [number format](Formatting.md#d3_format) function suitable for displaying a tick value. The specified *count* should have the same value as the count that is used to generate the tick values. You don't have to use the scale's built-in tick format, but it automatically computes the appropriate precision based on the fixed interval between tick values.
 
@@ -203,57 +203,57 @@ Log scales are similar to linear scales, except there's a logarithmic transform 
 
 As log(0) is negative infinity, a log scale must have either an exclusively-positive or exclusively-negative domain; the domain must not include or cross zero. A log scale with a positive domain has a well-defined behavior for positive values, and a log scale with a negative domain has a well-defined behavior for negative values (the input value is multiplied by -1, and the resulting output value is also multiplied by -1). The behavior of the scale is undefined if you pass a negative value to a log scale with a positive domain or vice versa.
 
-<a name="log" href="Quantitative-Scales#log">#</a> d3.scale.<b>log</b>()
+<a name="log" href="Quantitative-Scales.md#log">#</a> d3.scale.<b>log</b>()
 
 Constructs a new log scale with the default domain [1,10], the default range [0,1], and the base 10.
 
-<a name="_log" href="Quantitative-Scales#_log">#</a> <b>log</b>(<i>x</i>)
+<a name="_log" href="Quantitative-Scales.md#_log">#</a> <b>log</b>(<i>x</i>)
 
 Given a value *x* in the input domain, returns the corresponding value in the output range.
 
 Note: some [interpolators](#log_interpolate) **reuse return values**. For example, if the domain values are arbitrary objects, then [d3.interpolateObject](Transitions.md#d3_interpolateObject) is automatically applied and the scale reuses the returned object. Often, the return value of a scale is immediately used to set an [attribute](Selections.md#attr) or [style](Selections.md#style), and you don’t have to worry about this; however, if you need to store the scale’s return value, use string coercion or create a copy as appropriate.
 
-<a name="log_invert" href="Quantitative-Scales#log_invert">#</a> log.<b>invert</b>(<i>y</i>)
+<a name="log_invert" href="Quantitative-Scales.md#log_invert">#</a> log.<b>invert</b>(<i>y</i>)
 
 Returns the value in the input domain *x* for the corresponding value in the output range *y*. This represents the inverse mapping from range to domain. For a valid value *y* in the output range, log(log.invert(<i>y</i>)) equals *y*; similarly, for a valid value *x* in the input domain, log.invert(log(<i>x</i>)) equals *x*. Equivalently, you can construct the invert operator by building a new scale while swapping the domain and range. The invert operator is particularly useful for interaction, say to determine the value in the input domain that corresponds to the pixel location under the mouse.
 
 Note: the invert operator is only supported if the output range is numeric! D3 allows the output range to be any type; under the hood, [d3.interpolate](Transitions.md#d3_interpolate) or a custom interpolator of your choice is used to map the normalized parameter *t* to a value in the output range. Thus, the output range may be colors, strings, or even arbitrary objects. As there is no facility to "uninterpolate" arbitrary types, the invert operator is currently supported only on numeric ranges.
 
-<a name="log_domain" href="Quantitative-Scales#log_domain">#</a> log.<b>domain</b>([<i>numbers</i>])
+<a name="log_domain" href="Quantitative-Scales.md#log_domain">#</a> log.<b>domain</b>([<i>numbers</i>])
 
 If *numbers* is specified, sets the scale's input domain to the specified array of numbers. The array must contain two or more numbers. If the elements in the given array are not numbers, they will be coerced to numbers; this coercion happens similarly when the scale is called. Thus, a log scale can be used to encode any type that can be converted to numbers. If *numbers* is not specified, returns the scale's current input domain.
 
 As with linear scales (see [linear.domain](Quantitative-Scales.md#linear_domain)), log scales can also accept more than two values for the domain and range, thus resulting in polylog scale.
 
-<a name="log_range" href="Quantitative-Scales#log_range">#</a> log.<b>range</b>([<i>values</i>])
+<a name="log_range" href="Quantitative-Scales.md#log_range">#</a> log.<b>range</b>([<i>values</i>])
 
 If *values* is specified, sets the scale's output range to the specified array of values. The array must contain two or more values, to match the cardinality of the input domain, otherwise the longer of the two is truncated to match the other. The elements in the given array need not be numbers; any value that is supported by the underlying [interpolator](Quantitative-Scales.md#log_interpolate) will work. However, numeric ranges are required for the invert operator. If *values* is not specified, returns the scale's current output range.
 
-<a name="log_rangeRound" href="Quantitative-Scales#log_rangeRound">#</a> log.<b>rangeRound</b>(<i>values</i>)
+<a name="log_rangeRound" href="Quantitative-Scales.md#log_rangeRound">#</a> log.<b>rangeRound</b>(<i>values</i>)
 
 Sets the scale's output range to the specified array of values, while also setting the scale's interpolator to [d3.interpolateRound](Transitions.md#d3_interpolateRound). This is a convenience routine for when the values output by the scale should be exact integers, such as to avoid antialiasing artifacts. It is also possible to round the output values manually after the scale is applied.
 
-<a name="log_base" href="Quantitative-Scales#log_base">#</a> log.<b>base</b>([<i>base</i>])
+<a name="log_base" href="Quantitative-Scales.md#log_base">#</a> log.<b>base</b>([<i>base</i>])
 
 If *base* is specified, sets the base for this logarithmic scale. If *base* is not specified, returns the current base, which defaults to 10.
 
-<a name="log_interpolate" href="Quantitative-Scales#log_interpolate">#</a> log.<b>interpolate</b>([<i>factory</i>])
+<a name="log_interpolate" href="Quantitative-Scales.md#log_interpolate">#</a> log.<b>interpolate</b>([<i>factory</i>])
 
 If *factory* is specified, sets the scale's output interpolator using the specified *factory*. The interpolator factory defaults to [d3.interpolate](Transitions.md#d3_interpolate), and is used to map the normalized domain parameter *t* in [0,1] to the corresponding value in the output range. The interpolator factory will be used to construct interpolators for each adjacent pair of values from the output range. If *factory* is not specified, returns the scale's interpolator factory.
 
-<a name="log_clamp" href="Quantitative-Scales#log_clamp">#</a> log.<b>clamp</b>([<i>boolean</i>])
+<a name="log_clamp" href="Quantitative-Scales.md#log_clamp">#</a> log.<b>clamp</b>([<i>boolean</i>])
 
 If *boolean* is specified, enables or disables clamping accordingly. By default, clamping is disabled, such that if a value outside the input domain is passed to the scale, the scale may return a value outside the output range through linear extrapolation. For example, with the default domain and range of [0,1], an input value of 2 will return an output value of 2. If clamping is enabled, the normalized domain parameter *t* is clamped to the range [0,1], such that the return value of the scale is always within the scale's output range. If *boolean* is not specified, returns whether or not the scale currently clamps values to within the output range.
 
-<a name="log_nice" href="Quantitative-Scales#log_nice">#</a> log.<b>nice</b>()
+<a name="log_nice" href="Quantitative-Scales.md#log_nice">#</a> log.<b>nice</b>()
 
 Extends the domain so that it starts and ends on nice round values. This method typically modifies the scale's domain, and may only extend the bounds to the nearest round value. The nearest round value is based on integer powers of the scale’s [base](#log_base), which defaults to 10. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.20147987687960267, 0.996679553296417], the nice domain is [0.1, 1]. If the domain has more than two values, nicing the domain only affects the first and last value.
 
-<a name="log_ticks" href="Quantitative-Scales#log_ticks">#</a> log.<b>ticks</b>()
+<a name="log_ticks" href="Quantitative-Scales.md#log_ticks">#</a> log.<b>ticks</b>()
 
 Returns representative values from the scale's input domain. The returned tick values are uniformly spaced within each power of ten, and are guaranteed to be within the extent of the input domain. Ticks are often used to display reference lines, or tick marks, in conjunction with the visualized data. Note that the number of ticks cannot be customized (due to the nature of log scales); however, you can filter the returned array of values if you want to reduce the number of ticks.
 
-<a name="log_tickFormat" href="Quantitative-Scales#log_tickFormat">#</a> log.<b>tickFormat</b>([<i>count</i>, [<i>format</i>]])
+<a name="log_tickFormat" href="Quantitative-Scales.md#log_tickFormat">#</a> log.<b>tickFormat</b>([<i>count</i>, [<i>format</i>]])
 
 Returns a [number format](Formatting.md#d3_format) function suitable for displaying a tick value. The returned tick format is implemented as `d.toPrecision(1)`. If a *count* is specified, then some of the tick labels may not be displayed; this is useful if there is not enough room to fit all of the tick labels. However, note that the tick marks will still be displayed (so that the log scale distortion remains visible). When specifying a count, you may also override the *format* function; you can also specify a format specifier as a string, and it will automatically be wrapped with [d3.format](Formatting.md). For example, to get a tick formatter that will display 20 ticks of a currency:
 
@@ -271,7 +271,7 @@ Returns an exact copy of this scale. Changes to this scale will not affect the r
 
 Quantize scales are a variant of linear scales with a discrete rather than continuous range. The input domain is still continuous, and divided into uniform segments based on the number of values in (the cardinality of) the output range. The mapping is *linear* in that the output range value *y* can be expressed as a linear function of the input domain value *x*: *y* = *mx* + *b*. The input domain is typically a dimension of the data that you want to visualize, such as the height of students (measured in meters) in a sample population. The output range is typically a dimension of the desired output visualization, such as the height of bars (measured in pixels) in a histogram.
 
-<a name="quantize" href="Quantitative-Scales#quantize">#</a> d3.scale.<b>quantize</b>()
+<a name="quantize" href="Quantitative-Scales.md#quantize">#</a> d3.scale.<b>quantize</b>()
 
 Constructs a new quantize scale with the default domain [0,1] and the default range [0,1]. Thus, the default quantize scale is equivalent to the [round](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Math/round) function for numbers; for example quantize(0.49) returns 0, and quantize(0.51) returns 1.
 
@@ -281,7 +281,7 @@ Constructs a new quantize scale with the default domain [0,1] and the default ra
  //q.invertExtent('a') returns [0, 0.3333333333333333]
 ```
 
-<a name="_quantize" href="Quantitative-Scales#_quantize">#</a> <b>quantize</b>(<i>x</i>)
+<a name="_quantize" href="Quantitative-Scales.md#_quantize">#</a> <b>quantize</b>(<i>x</i>)
 
 Given a value *x* in the input domain, returns the corresponding value in the output range.
 
@@ -289,11 +289,11 @@ Given a value *x* in the input domain, returns the corresponding value in the ou
 
 Returns the extent of values in the input domain [<i>x0</i>, <i>x1</i>] for the corresponding value in the output range *y*, representing the inverse mapping from range to domain. This method is useful for interaction, say to determine the value in the input domain that corresponds to the pixel location under the mouse.
 
-<a name="quantize_domain" href="Quantitative-Scales#quantize_domain">#</a> quantize.<b>domain</b>([<i>numbers</i>])
+<a name="quantize_domain" href="Quantitative-Scales.md#quantize_domain">#</a> quantize.<b>domain</b>([<i>numbers</i>])
 
 If *numbers* is specified, sets the scale's input domain to the specified two-element array of numbers. If the array contains more than two numbers, only the first and last number are used. If the elements in the given array are not numbers, they will be coerced to numbers; this coercion happens similarly when the scale is called. Thus, a quantize scale can be used to encode any type that can be converted to numbers. If *numbers* is not specified, returns the scale's current input domain.
 
-<a name="quantize_range" href="Quantitative-Scales#quantize_range">#</a> quantize.<b>range</b>([<i>values</i>])
+<a name="quantize_range" href="Quantitative-Scales.md#quantize_range">#</a> quantize.<b>range</b>([<i>values</i>])
 
 If *values* is specified, sets the scale's output range to the specified array of values. The array may contain any number of discrete values. The elements in the given array need not be numbers; any value or type will work. If *values* is not specified, returns the scale's current output range.
 
@@ -305,11 +305,11 @@ Returns an exact copy of this scale. Changes to this scale will not affect the r
 
 Quantile scales map an input domain to a discrete range. Although the input domain is continuous and the scale will accept any reasonable input value, the input domain is specified as a discrete set of values. The number of values in (the cardinality of) the output range determines the number of quantiles that will be computed from the input domain. To compute the quantiles, the input domain is sorted, and treated as a [population of discrete values](http://en.wikipedia.org/wiki/Quantile#Quantiles_of_a_population). The input domain is typically a dimension of the data that you want to visualize, such as the daily change of the stock market. The output range is typically a dimension of the desired output visualization, such as a diverging color scale.
 
-<a name="quantile" href="Quantitative-Scales#quantile">#</a> d3.scale.<b>quantile</b>()
+<a name="quantile" href="Quantitative-Scales.md#quantile">#</a> d3.scale.<b>quantile</b>()
 
 Constructs a new quantile scale with an empty domain and an empty range. The quantile scale is invalid until both a domain and range are specified.
 
-<a name="_quantile" href="Quantitative-Scales#_quantile">#</a> <b>quantile</b>(<i>x</i>)
+<a name="_quantile" href="Quantitative-Scales.md#_quantile">#</a> <b>quantile</b>(<i>x</i>)
 
 Given a value *x* in the input domain, returns the corresponding value in the output range.
 
@@ -317,15 +317,15 @@ Given a value *x* in the input domain, returns the corresponding value in the ou
 
 Returns the extent of values in the input domain [<i>x0</i>, <i>x1</i>] for the corresponding value in the output range *y*, representing the inverse mapping from range to domain. This method is useful for interaction, say to determine the value in the input domain that corresponds to the pixel location under the mouse.
 
-<a name="quantile_domain" href="Quantitative-Scales#quantile_domain">#</a> quantile.<b>domain</b>([<i>numbers</i>])
+<a name="quantile_domain" href="Quantitative-Scales.md#quantile_domain">#</a> quantile.<b>domain</b>([<i>numbers</i>])
 
 If *numbers* is specified, sets the input domain of the quantile scale to the specified set of discrete numeric values. The array must not be empty, and must contain at least one numeric value; NaN, null and undefined values are ignored and not considered part of the sample population. If the elements in the given array are not numbers, they will be coerced to numbers; this coercion happens similarly when the scale is called. A copy of the input array is sorted and stored internally. Thus, a quantile scale can be used to encode any type that can be converted to numbers. If *numbers* is not specified, returns the scale's current input domain.
 
-<a name="quantile_range" href="Quantitative-Scales#quantile_range">#</a> quantile.<b>range</b>([<i>values</i>])
+<a name="quantile_range" href="Quantitative-Scales.md#quantile_range">#</a> quantile.<b>range</b>([<i>values</i>])
 
 If *values* is specified, sets the discrete values in the output range. The array must not be empty, and may contain any type of value. The number of values in (the cardinality, or length, of) the *values* array determines the number of quantiles that are computed. For example, to compute quartiles, *values* must be an array of four elements such as [0, 1, 2, 3]. If *values* is not specified, returns the current output range.
 
-<a name="quantile_quantiles" href="Quantitative-Scales#quantile_quantiles">#</a> quantile.<b>quantiles</b>()
+<a name="quantile_quantiles" href="Quantitative-Scales.md#quantile_quantiles">#</a> quantile.<b>quantiles</b>()
 
 Returns the quantile thresholds. If the output range contains *n* discrete values, the returned threshold array will contain *n* - 1 values. Values less than the first element in the thresholds array, quantiles()[0], are considered in the first quantile; greater values less than the second threshold are in the second quantile, and so on. Internally, the thresholds array is used with [d3.bisect](Arrays.md#d3_bisect) to find the output quantile associated with the given input value.
 

--- a/Requests.md
+++ b/Requests.md
@@ -103,19 +103,19 @@ If *listener* is not specified, returns the currently-assigned listener for the 
 
 Often, d3.xhr is not used directly. Instead, one of the type-specific methods is used instead, such as [d3.text](#d3_text) for plain text, [d3.json](#d3_json) for JSON, [d3.xml](#d3_xml) for XML, [d3.html](#d3_html) for HTML, [d3.csv](#d3_csv) for comma-separated values, and [d3.tsv](#d3_tsv) for tabulation-separated values.
 
-<a name="d3_text" href="Requests#d3_text">#</a> d3.<b>text</b>(<i>url</i>[, <i>mimeType</i>][, <i>callback</i>])
+<a name="d3_text" href="Requests.md#d3_text">#</a> d3.<b>text</b>(<i>url</i>[, <i>mimeType</i>][, <i>callback</i>])
 
 Creates a request for the text file at the specified *url*. An optional *mime type* may be specified as the second argument, such as "text/plain". If a *callback* is specified, the request is immediately issued with the GET method, and the callback will be invoked asynchronously when the file is loaded or the request fails; the callback is invoked with two arguments: the error, if any, and the response text. The response text is undefined if an error occurs. If no callback is specified, the returned request can be issued using xhr.get or similar, and handled using xhr.on.
 
-<a name="d3_json" href="Requests#d3_json">#</a> d3.<b>json</b>(<i>url</i>[, <i>callback</i>])
+<a name="d3_json" href="Requests.md#d3_json">#</a> d3.<b>json</b>(<i>url</i>[, <i>callback</i>])
 
 Creates a request for the [JSON](http://json.org) file at the specified *url* with the mime type "application/json". If a *callback* is specified, the request is immediately issued with the GET method, and the callback will be invoked asynchronously when the file is loaded or the request fails; the callback is invoked with two arguments: the error, if any, and the parsed JSON. The parsed JSON is undefined if an error occurs. If no callback is specified, the returned request can be issued using xhr.get or similar, and handled using xhr.on.
 
-<a name="d3_xml" href="Requests#d3_xml">#</a> d3.<b>xml</b>(<i>url</i>[, <i>mimeType</i>][, <i>callback</i>])
+<a name="d3_xml" href="Requests.md#d3_xml">#</a> d3.<b>xml</b>(<i>url</i>[, <i>mimeType</i>][, <i>callback</i>])
 
 Creates a request for the XML file at the specified *url*. An optional *mime type* may be specified as the second argument, such as "application/xml". If a *callback* is specified, the request is immediately issued with the GET method, and the callback will be invoked asynchronously when the file is loaded or the request fails; the callback is invoked with two arguments: the error, if any, and the parsed XML as a [document](http://www.w3.org/TR/XMLHttpRequest/#the-responsexml-attribute). The parsed XML is undefined if an error occurs. If no callback is specified, the returned request can be issued using xhr.get or similar, and handled using xhr.on.
 
-<a name="d3_html" href="Requests#d3_html">#</a> d3.<b>html</b>(<i>url</i>[, <i>callback</i>])
+<a name="d3_html" href="Requests.md#d3_html">#</a> d3.<b>html</b>(<i>url</i>[, <i>callback</i>])
 
 Creates a request for the HTML file at the specified *url* with the mime type "text/html". If a *callback* is specified, the request is immediately issued with the GET method, and the callback will be invoked asynchronously when the file is loaded or the request fails; the callback is invoked with two arguments: the error, if any, and the parsed HTML as a [document fragment](https://developer.mozilla.org/en-US/docs/DOM/range.createContextualFragment). The parsed HTML is undefined if an error occurs. If no callback is specified, the returned request can be issued using xhr.get or similar, and handled using xhr.on.
 
@@ -123,6 +123,6 @@ Creates a request for the HTML file at the specified *url* with the mime type "t
 
 Creates a request for the [CSV](CSV.md) file at the specified *url* with the mime type "text/csv". If a *callback* is specified, the request is immediately issued with the GET method, and the callback will be invoked asynchronously when the file is loaded or the request fails; the callback is invoked with two arguments: the error, if any, and the array of [parsed rows](CSV.md#parse) per [RFC 4180](http://tools.ietf.org/html/rfc4180). The rows array is undefined if an error occurs. If no callback is specified, the returned request can be issued using xhr.get or similar, and handled using xhr.on.
 
-<a name="d3_tsv" href="CSV#tsv">#</a> d3.<b>tsv</b>(<i>url</i>[, <i>accessor</i>][, <i>callback</i>])
+<a name="d3_tsv" href="CSV.md#tsv">#</a> d3.<b>tsv</b>(<i>url</i>[, <i>accessor</i>][, <i>callback</i>])
 
 Creates a request for the [TSV](CSV.md#d3_tsv) file at the specified *url* with the mime type "text/tab-separated-values". If a *callback* is specified, the request is immediately issued with the GET method, and the callback will be invoked asynchronously when the file is loaded or the request fails; the callback is invoked with two arguments: the error, if any, and the array of [parsed rows](CSV.md#tsv_parse) per [RFC 4180](http://tools.ietf.org/html/rfc4180). The rows array is undefined if an error occurs. If no callback is specified, the returned request can be issued using xhr.get or similar, and handled using xhr.on.

--- a/SVG-Axes.md
+++ b/SVG-Axes.md
@@ -24,11 +24,11 @@ D3’s [axis component](http://bl.ocks.org/mbostock/1166403) displays reference 
 
 The axis component is designed to work with D3’s [quantitative](Quantitative-Scales.md), [time](Time-Scales.md) and [ordinal](Ordinal-Scales.md) scales.
 
-<a name="axis" href="SVG-Axes#axis">#</a> d3.svg.<b>axis</b>()
+<a name="axis" href="SVG-Axes.md#axis">#</a> d3.svg.<b>axis</b>()
 
 Create a new default axis.
 
-<a name="_axis" href="SVG-Axes#_axis">#</a> <b>axis</b>(<i>selection</i>)
+<a name="_axis" href="SVG-Axes.md#_axis">#</a> <b>axis</b>(<i>selection</i>)
 
 Apply the axis to a [selection](Selections.md) or [transition](Transitions.md). The selection must contain an `svg` or `g` element. For example:
 

--- a/SVG-Events.md
+++ b/SVG-Events.md
@@ -2,10 +2,10 @@
 
 **The [D3 4.0 API Reference](https://github.com/d3/d3/blob/master/API.md) has moved. This page describes the D3 3.x API.**
 
-<a name="mouse" href="SVG-Events#mouse">#</a> d3.svg.<b>mouse</b>(<i>container</i>)
+<a name="mouse" href="SVG-Events.md#mouse">#</a> d3.svg.<b>mouse</b>(<i>container</i>)
 
 Renamed to [d3.mouse](Selections.md#d3_mouse).
 
-<a name="touches" href="SVG-Events#touches">#</a> d3.svg.<b>touches</b>(<i>container</i>)
+<a name="touches" href="SVG-Events.md#touches">#</a> d3.svg.<b>touches</b>(<i>container</i>)
 
 Renamed to [d3.touches](Selections.md#d3_touches).

--- a/SVG-Shapes.md
+++ b/SVG-Shapes.md
@@ -10,31 +10,31 @@ A shape generator, such as that returned by [d3.svg.arc](SVG-Shapes.md#arc), is 
 
 All SVG shapes can be transformed using the [transform](http://www.w3.org/TR/SVG/coords.html#TransformAttribute) attribute. You can apply the transform either to the shape directly, or to a containing [g](http://www.w3.org/TR/SVG/struct.html#Groups) element. Thus, when a shape is defined as "axis-aligned", that merely means axis-aligned within the local coordinate system; you can still rotate and otherwise transform the shape. Shapes can be filled and stroked using the [fill](http://www.w3.org/TR/SVG/painting.html#FillProperties) and [stroke](http://www.w3.org/TR/SVG/painting.html#StrokeProperties) styles. (You can also use the attributes of the same name, but styles are recommended as they are compatible with external stylesheets.)
 
-<a name="svg_rect" href="SVG-Shapes#svg_rect">#</a> svg:<b>rect</b> x="0" y="0" width="0" height="0" rx="0" ry="0"
+<a name="svg_rect" href="SVG-Shapes.md#svg_rect">#</a> svg:<b>rect</b> x="0" y="0" width="0" height="0" rx="0" ry="0"
 
 The [rect](http://www.w3.org/TR/SVG/shapes.html#RectElement) element defines an axis-aligned rectangle. The top-left corner of the rectangle is positioned using the *x* and *y* attributes, while its size is specified using *width* and *height*. A rounded rectangle can be produced using the optional *rx* and *ry* attributes.
 
-<a name="svg_circle" href="SVG-Shapes#svg_circle">#</a> svg:<b>circle</b> cx="0" cy="0" r="0"
+<a name="svg_circle" href="SVG-Shapes.md#svg_circle">#</a> svg:<b>circle</b> cx="0" cy="0" r="0"
 
 The [circle](http://www.w3.org/TR/SVG/shapes.html#CircleElement) element defines a circle based on a center point and a radius. The center is positioned using the *cx* and *cy* attributes, while the radius is specified using the *r* attribute.
 
-<a name="svg_ellipse" href="SVG-Shapes#svg_ellipse">#</a> svg:<b>ellipse</b> cx="0" cy="0" rx="0" ry="0"
+<a name="svg_ellipse" href="SVG-Shapes.md#svg_ellipse">#</a> svg:<b>ellipse</b> cx="0" cy="0" rx="0" ry="0"
 
 The [ellipse](http://www.w3.org/TR/SVG/shapes.html#EllipseElement) element defines an axis-aligned ellipse based on a center point and two radii. The center is positioned using the *cx* and *cy* attributes, while the radii are specified using the *rx* and *ry* attributes.
 
-<a name="svg_line" href="SVG-Shapes#svg_line">#</a> svg:<b>line</b> x1="0" y1="0" x2="0" y2="0"
+<a name="svg_line" href="SVG-Shapes.md#svg_line">#</a> svg:<b>line</b> x1="0" y1="0" x2="0" y2="0"
 
 The [line](http://www.w3.org/TR/SVG/shapes.html#LineElement) element defines a line segment that starts at one point and ends at another. The first point is specified using the *x1* and *y1* attributes, while the second point is specified using the *x2* and *y2* attributes. The line element is a popular choice for drawing rules, reference lines, axes and tick marks.
 
-<a name="svg_polyline" href="SVG-Shapes#svg_polyline">#</a> svg:<b>polyline</b> points=""
+<a name="svg_polyline" href="SVG-Shapes.md#svg_polyline">#</a> svg:<b>polyline</b> points=""
 
 The [polyline](http://www.w3.org/TR/SVG/shapes.html#PolylineElement) element defines a set of connected straight line segments. Typically, polyline elements define open shapes. The points that make up the polyline are specified using the *points* attribute. Note: in D3, it is typically more convenient and flexible to use the [d3.svg.line](SVG-Shapes.md#line) path generator in conjunction with a path element.
 
-<a name="svg_polygon" href="SVG-Shapes#svg_polygon">#</a> svg:<b>polygon</b> points=""
+<a name="svg_polygon" href="SVG-Shapes.md#svg_polygon">#</a> svg:<b>polygon</b> points=""
 
 The [polygon](http://www.w3.org/TR/SVG/shapes.html#PolygonElement) element defines a closed shape consisting of a set of connected straight line segments. The points that make up the polygon are specified using the *points* attribute. Note: in D3, it is typically more convenient and flexible to use the [d3.svg.line](SVG-Shapes.md#line) path generator in conjunction with a path element. The line can be closed using the [closepath](http://www.w3.org/TR/SVG/paths.html#PathDataClosePathCommand) "Z" command.
 
-<a name="svg_text" href="SVG-Shapes#svg_text">#</a> svg:<b>text</b> x="0" y="0" dx="0" dy="0" text-anchor="start"
+<a name="svg_text" href="SVG-Shapes.md#svg_text">#</a> svg:<b>text</b> x="0" y="0" dx="0" dy="0" text-anchor="start"
 
 The [text](http://www.w3.org/TR/SVG/text.html#TextElement) element defines a graphics element consisting of text. The text content of the text element (see the [text](Selections.md#text) operator) define the characters to be rendered. The anchor position of the text element is controlled using the *x* and *y* attributes; additionally, the text can be offset from the anchor using *dx* and *dy* attributes. This offset is particularly convenient for controlling the text margin and baseline, as you can use "em" units which are relative to the font size. The horizontal text alignment is controlling using the *text-anchor* attribute. Here are a few examples:
 
@@ -52,7 +52,7 @@ The [text](http://www.w3.org/TR/SVG/text.html#TextElement) element defines a gra
 
 It's possible that there is a better way to specify the text baseline using SVG's [baseline alignment properties](http://www.w3.org/TR/SVG/text.html#BaselineAlignmentProperties), but these don't seem to be widely supported by browsers. Lastly, the font color is typically specified using the *fill* style (you can also use *stroke*), and the font is controlled using the *font*, *font-family*, *font-size* and related styles. Some browsers also support CSS3 properties, such as *text-shadow*.
 
-<a name="svg_path" href="SVG-Shapes#svg_path">#</a> svg:<b>path</b> d="" transform=""
+<a name="svg_path" href="SVG-Shapes.md#svg_path">#</a> svg:<b>path</b> d="" transform=""
 
 The [path](http://www.w3.org/TR/SVG/paths.html#PathElement) element represents the outline of a shape which can be filled, stroked, used as a clipping path, or any combination of the three. The *d* attribute defines the path data, which is a [mini-language](http://www.w3.org/TR/SVG/paths.html#PathData) of path commands, such as *moveto* (M), *lineto* (L) and *closepath* (Z). The path element is a generalization of all other shapes in SVG, and can be used to draw nearly anything!
 
@@ -78,7 +78,7 @@ Whatever data is bound to `g` (in this example) will be passed to the `line` ins
 
 A path generator, such as that returned by d3.svg.line, is both an object and a function. That is: you can call the generator like any other function, and the generator has additional methods that change its behavior. Like other classes in D3, path generators follow the method chaining pattern where setter methods return the generator itself, allowing multiple setters to be invoked in a concise statement.
 
-<a name="line" href="SVG-Shapes#line">#</a> d3.svg.<b>line</b>()
+<a name="line" href="SVG-Shapes.md#line">#</a> d3.svg.<b>line</b>()
 
 Constructs a new line generator with the default *x*- and *y*-accessor functions (that assume the input data is a two-element array of numbers; see below for details), and linear interpolation. The returned function generates path data for an open piecewise linear curve, or polyline, as in a line chart:
 
@@ -93,11 +93,11 @@ g.append("path")
 
 The line generator is designed to work in conjunction with the [area](SVG-Shapes.md#area) generator. For example, when producing an area chart, you might use an area generator with a fill style, and a line generator with a stroke style to emphasize the top edge of the area. Since the line generator is only used to set the *d* attribute, you can control the appearance of the line using standard SVG styles and attributes, such as *fill*, *stroke* and *stroke-width*.
 
-<a name="_line" href="SVG-Shapes#_line">#</a> <b>line</b>(<i>data</i>)
+<a name="_line" href="SVG-Shapes.md#_line">#</a> <b>line</b>(<i>data</i>)
 
 Returns the path data string for the specified array of *data* elements, or null if the path is empty.
 
-<a name="line_x" href="SVG-Shapes#line_x">#</a> line.<b>x</b>([<i>x</i>])
+<a name="line_x" href="SVG-Shapes.md#line_x">#</a> line.<b>x</b>([<i>x</i>])
 
 If *x* is specified, sets the *x*-accessor to the specified function or constant. If *x* is not specified, returns the current *x*-accessor. This accessor is invoked for each element in the data array passed to the line generator. The default accessor assumes that each input element is a two-element array of numbers:
 
@@ -120,7 +120,7 @@ var line = d3.svg.line()
 
 The *x*-accessor is invoked in the same manner as other value functions in D3. The *this* context of the function is the current element in the selection. (Technically, the same *this* context that invokes the line function; however, in the common case that the line generator is passed to the [attr](Selections.md#attr) operator, the *this* context will be the associated DOM element.) The function is passed two arguments, the current datum (d) and the current index (i). In this context, the index is the index into the array of control points, rather than the index of the current element in the selection. The *x*-accessor is invoked exactly once per datum, in the order specified by the data array. Thus, it is possible to specify a nondeterministic accessor, such as a random number generator. It is also possible to specify the *x*-accessor as a constant rather than a function, in which case all points will have the same *x*-coordinate.
 
-<a name="line_y" href="SVG-Shapes#line_y">#</a> line.<b>y</b>([<i>y</i>])
+<a name="line_y" href="SVG-Shapes.md#line_y">#</a> line.<b>y</b>([<i>y</i>])
 
 If *y* is specified, sets the *y*-accessor to the specified function or constant. If *y* is not specified, returns the current *y*-accessor. This accessor is invoked for each element in the data array passed to the line generator. The default accessor assumes that each input element is a two-element array of numbers:
 
@@ -132,7 +132,7 @@ function y(d) {
 
 For an example of how to specify a *y*-accessor, see the similar [x](SVG-Shapes.md#line_x) accessor. Note that, like most other graphics libraries, SVG uses the top-left corner as the origin and thus higher values of *y* are *lower* on the screen. For visualization we often want the origin in the bottom-left corner instead; one easy way to accomplish this is to invert the range of the *y*-scale by using range([h, 0]) instead of range([0, h]).
 
-<a name="line_interpolate" href="SVG-Shapes#line_interpolate">#</a> line.<b>interpolate</b>([<i>interpolate</i>])
+<a name="line_interpolate" href="SVG-Shapes.md#line_interpolate">#</a> line.<b>interpolate</b>([<i>interpolate</i>])
 
 If *interpolate* is specified, sets the interpolation mode to the specified string or function. If *interpolate* is not specified, returns the current interpolation mode. The following named interpolation modes are supported:
 
@@ -175,7 +175,7 @@ function interpolateLinear(points) {
 
 See [bl.ocks.org/3310323](http://bl.ocks.org/mbostock/3310323) for another example of custom line interpolation.
 
-<a name="line_tension" href="SVG-Shapes#line_tension">#</a> line.<b>tension</b>([<i>tension</i>])
+<a name="line_tension" href="SVG-Shapes.md#line_tension">#</a> line.<b>tension</b>([<i>tension</i>])
 
 If *tension* is specified, sets the Cardinal spline interpolation tension to the specified number in the range [0, 1]. If *tension* is not specified, returns the current tension. The tension only affects the Bundle and Cardinal interpolation modes: bundle, cardinal, cardinal-open and cardinal-closed. The default tension is 0.7. In some sense, this can be interpreted as the length of the tangent; 1 will yield all zero tangents, and 0 yields a [Catmull-Rom spline](http://en.wikipedia.org/wiki/Cubic_Hermite_spline#Catmull.E2.80.93Rom_spline).
 
@@ -200,15 +200,15 @@ line.defined(function(d) { return !isNaN(d[1]); });
 
 If a datum is defined but surrounded by undefined data (or the end of the array), that datum will not be visible.
 
-<a name="line_radial" href="SVG-Shapes#line_radial">#</a> d3.svg.line.<b>radial</b>()
+<a name="line_radial" href="SVG-Shapes.md#line_radial">#</a> d3.svg.line.<b>radial</b>()
 
 Constructs a new radial line generator with the default *radius*- and *angle*-accessor functions (that assume the input data is a two-element array of numbers; see below for details), and linear interpolation. The returned function generates path data for an open piecewise linear curve, or polyline, as with the Cartesian [line](SVG-Shapes.md#line) generator.
 
-<a name="_line_radial" href="SVG-Shapes#_line_radial">#</a> <b>line</b>(<i>data</i>)
+<a name="_line_radial" href="SVG-Shapes.md#_line_radial">#</a> <b>line</b>(<i>data</i>)
 
 Returns the path data string for the specified array of *data* elements.
 
-<a name="line_radial_radius" href="SVG-Shapes#line_radial_radius">#</a> line.<b>radius</b>([<i>radius</i>])
+<a name="line_radial_radius" href="SVG-Shapes.md#line_radial_radius">#</a> line.<b>radius</b>([<i>radius</i>])
 
 If *radius* is specified, sets the *radius*-accessor to the specified function or constant. If *radius* is not specified, returns the current *radius*-accessor. This accessor is invoked for each element in the data array passed to the line generator. The default accessor assumes that each input element is a two-element array of numbers:
 
@@ -220,7 +220,7 @@ function radius(d) {
 
 This method is a transformation of the Cartesian [line.x](SVG-Shapes.md#line_x) method.
 
-<a name="line_radial_angle" href="SVG-Shapes#line_radial_angle">#</a> line.<b>angle</b>([<i>angle</i>])
+<a name="line_radial_angle" href="SVG-Shapes.md#line_radial_angle">#</a> line.<b>angle</b>([<i>angle</i>])
 
 If *angle* is specified, sets the *angle*-accessor to the specified function or constant in radians. If *angle* is not specified, returns the current *angle*-accessor. This accessor is invoked for each element in the data array passed to the line generator. The default accessor assumes that each input element is a two-element array of numbers:
 
@@ -232,19 +232,19 @@ function angle(d) {
 
 This method is a transformation of the Cartesian [line.y](SVG-Shapes.md#line_y) method.
 
-<a name="line_radial_interpolate" href="SVG-Shapes#line_radial_interpolate">#</a> line.<b>interpolate</b>([<i>interpolate</i>])
+<a name="line_radial_interpolate" href="SVG-Shapes.md#line_radial_interpolate">#</a> line.<b>interpolate</b>([<i>interpolate</i>])
 
 See the Cartesian [line.interpolate](SVG-Shapes.md#line_interpolate) method.  The interpolation occurs after projecting to Cartesian space.
 
-<a name="line_radial_tension" href="SVG-Shapes#line_radial_tension">#</a> line.<b>tension</b>([<i>tension</i>])
+<a name="line_radial_tension" href="SVG-Shapes.md#line_radial_tension">#</a> line.<b>tension</b>([<i>tension</i>])
 
 See the Cartesian [line.tension](SVG-Shapes.md#line_tension) method.  The interpolation occurs after projecting to Cartesian space.
 
-<a name="line_radial_defined" href="SVG-Shapes#line_radial_defined">#</a> line.<b>defined</b>([<i>defined</i>])
+<a name="line_radial_defined" href="SVG-Shapes.md#line_radial_defined">#</a> line.<b>defined</b>([<i>defined</i>])
 
 See the Cartesian [line.defined](SVG-Shapes.md#line_defined) method.
 
-<a name="area" href="SVG-Shapes#area">#</a> d3.svg.<b>area</b>()
+<a name="area" href="SVG-Shapes.md#area">#</a> d3.svg.<b>area</b>()
 
 Constructs a new area generator with the default *x*-, *y0*- and *y1*-accessor functions (that assume the input data is a two-element array of numbers; see below for details), and linear interpolation. The returned function generates path data for a closed piecewise linear curve, or polygon, as in an area chart:
 
@@ -256,11 +256,11 @@ The area generator is designed to work in conjunction with the [line](SVG-Shapes
 
 To create [streamgraphs](http://mbostock.github.com/d3/ex/stream.html) (stacked area charts), use the [stack](Stack-Layout.md) layout. This layout sets the y0 attribute for each value in a series, which can be used from the *y0*- and *y1*-accessors. Note that each series must have the same number of values per series, and each value must have the same *x*-coordinate; if you have missing data or inconsistent *x*-coordinates per series, you must resample and interpolate your data before computing the stacked layout.
 
-<a name="_area" href="SVG-Shapes#_area">#</a> <b>area</b>(<i>data</i>)
+<a name="_area" href="SVG-Shapes.md#_area">#</a> <b>area</b>(<i>data</i>)
 
 Returns the path data string for the specified array of *data* elements, or null if the path is empty.
 
-<a name="area_x" href="SVG-Shapes#area_x">#</a> area.<b>x</b>([<i>x</i>])
+<a name="area_x" href="SVG-Shapes.md#area_x">#</a> area.<b>x</b>([<i>x</i>])
 
 If *x* is specified, sets the *x*-accessor to the specified function or constant. If *x* is not specified, returns the current *x*-accessor. This accessor is invoked for each element in the data array passed to the area generator. The default accessor assumes that each input element is a two-element array of numbers:
 
@@ -284,23 +284,23 @@ var area = d3.svg.area()
 
 The *x*-accessor is invoked in the same manner as other value functions in D3. The *this* context of the function is the current element in the selection. (Technically, the same *this* context that invokes the area function; however, in the common case that the area generator is passed to the [attr](Selections.md#attr) operator, the *this* context will be the associated DOM element.) The function is passed two arguments, the current datum (d) and the current index (i). In this context, the index is the index into the array of control points, rather than the index of the current element in the selection. The *x*-accessor is invoked exactly once per datum, in the order specified by the data array. Thus, it is possible to specify a non-deterministic accessor, such as a random number generator. It is also possible to specify the *x*-accessor as a constant rather than a function, in which case all points will have the same *x*-coordinate.
 
-<a name="area_x0" href="SVG-Shapes#area_x0">#</a> area.<b>x0</b>([<i>x0</i>])
+<a name="area_x0" href="SVG-Shapes.md#area_x0">#</a> area.<b>x0</b>([<i>x0</i>])
 
 …
 
-<a name="area_x1" href="SVG-Shapes#area_x1">#</a> area.<b>x1</b>([<i>x1</i>])
+<a name="area_x1" href="SVG-Shapes.md#area_x1">#</a> area.<b>x1</b>([<i>x1</i>])
 
 …
 
-<a name="area_y" href="SVG-Shapes#area_y">#</a> area.<b>y</b>([<i>y</i>])
+<a name="area_y" href="SVG-Shapes.md#area_y">#</a> area.<b>y</b>([<i>y</i>])
 
 …
 
-<a name="area_y0" href="SVG-Shapes#area_y0">#</a> area.<b>y0</b>([<i>y0</i>])
+<a name="area_y0" href="SVG-Shapes.md#area_y0">#</a> area.<b>y0</b>([<i>y0</i>])
 
 If *y0* is specified, sets the *y0*-accessor to the specified function or constant. If *y0* is not specified, returns the current *y0*-accessor. This accessor is invoked for each element in the data array passed to the area generator. The default accessor is the constant zero, thus using a fixed baseline at *y* = 0. For an example of how to specify a *y0*-accessor, see the similar [x](SVG-Shapes.md#area_x) accessor.
 
-<a name="area_y1" href="SVG-Shapes#area_y1">#</a> area.<b>y1</b>([<i>y1</i>])
+<a name="area_y1" href="SVG-Shapes.md#area_y1">#</a> area.<b>y1</b>([<i>y1</i>])
 
 If *y1* is specified, sets the *y1*-accessor to the specified function or constant. If *y1* is not specified, returns the current *y1*-accessor. This accessor is invoked for each element in the data array passed to the area generator. The default accessor assumes that each input element is a two-element array of numbers:
 
@@ -312,7 +312,7 @@ function y1(d) {
 
 For an example of how to specify a *y1*-accessor, see the similar [x](SVG-Shapes.md#area_x) accessor. Note that, like most other graphics libraries, SVG uses the top-left corner as the origin and thus higher values of *y* are *lower* on the screen. For visualization we often want the origin in the bottom-left corner instead; one easy way to accomplish this is to invert the range of the *y*-scale by using range([h, 0]) instead of range([0, h]).
 
-<a name="area_interpolate" href="SVG-Shapes#area_interpolate">#</a> area.<b>interpolate</b>([<i>interpolate</i>])
+<a name="area_interpolate" href="SVG-Shapes.md#area_interpolate">#</a> area.<b>interpolate</b>([<i>interpolate</i>])
 
 If *interpolate* is specified, sets the interpolation mode to the specified string or function. If *interpolate* is not specified, returns the current interpolation mode. The following named modes are supported:
 
@@ -351,7 +351,7 @@ function interpolateLinear(points) {
 
 See [bl.ocks.org/3310323](http://bl.ocks.org/mbostock/3310323) for another example of custom interpolation.
 
-<a name="area_tension" href="SVG-Shapes#area_tension">#</a> area.<b>tension</b>([<i>tension</i>])
+<a name="area_tension" href="SVG-Shapes.md#area_tension">#</a> area.<b>tension</b>([<i>tension</i>])
 
 If *tension* is specified, sets the Cardinal spline interpolation tension to the specified number in the range [0, 1]. If *tension* is not specified, returns the current tension. The tension only affects the Cardinal interpolation modes: cardinal, cardinal-open and cardinal-closed. The default tension is 0.7. In some sense, this can be interpreted as the length of the tangent; 1 will yield all zero tangents, and 0 yields a [Catmull-Rom spline](http://en.wikipedia.org/wiki/Cubic_Hermite_spline#Catmull.E2.80.93Rom_spline). Note that the tension must be specified as a constant, rather than a function, as it is constant for the entirety of the area.
 
@@ -363,39 +363,39 @@ Gets or sets the accessor function that controls where the area is defined. If *
 area.defined(function(d) { return !isNaN(d[1]); });
 ```
 
-<a name="area_radial" href="SVG-Shapes#area_radial">#</a> d3.svg.area.<b>radial</b>()
+<a name="area_radial" href="SVG-Shapes.md#area_radial">#</a> d3.svg.area.<b>radial</b>()
 
 …
 
-<a name="_area_radial" href="SVG-Shapes#_area_radial">#</a> <b>area</b>(<i>data</i>)
+<a name="_area_radial" href="SVG-Shapes.md#_area_radial">#</a> <b>area</b>(<i>data</i>)
 
 Returns the path data string for the specified array of *data* elements.
 
-<a name="area_radial_radius" href="SVG-Shapes#area_radial_radius">#</a> area.<b>radius</b>([<i>radius</i>])
+<a name="area_radial_radius" href="SVG-Shapes.md#area_radial_radius">#</a> area.<b>radius</b>([<i>radius</i>])
 
 …
 
-<a name="area_radial_innerRadius" href="SVG-Shapes#area_radial_innerRadius">#</a> area.<b>innerRadius</b>([<i>radius</i>])
+<a name="area_radial_innerRadius" href="SVG-Shapes.md#area_radial_innerRadius">#</a> area.<b>innerRadius</b>([<i>radius</i>])
 
 …
 
-<a name="area_radial_outerRadius" href="SVG-Shapes#area_radial_outerRadius">#</a> area.<b>outerRadius</b>([<i>radius</i>])
+<a name="area_radial_outerRadius" href="SVG-Shapes.md#area_radial_outerRadius">#</a> area.<b>outerRadius</b>([<i>radius</i>])
 
 …
 
-<a name="area_radial_angle" href="SVG-Shapes#area_radial_angle">#</a> area.<b>angle</b>([<i>angle</i>])
+<a name="area_radial_angle" href="SVG-Shapes.md#area_radial_angle">#</a> area.<b>angle</b>([<i>angle</i>])
 
 …
 
-<a name="area_radial_startAngle" href="SVG-Shapes#area_radial_startAngle">#</a> area.<b>startAngle</b>([<i>angle</i>])
+<a name="area_radial_startAngle" href="SVG-Shapes.md#area_radial_startAngle">#</a> area.<b>startAngle</b>([<i>angle</i>])
 
 …
 
-<a name="area_radial_endAngle" href="SVG-Shapes#area_radial_endAngle">#</a> area.<b>endAngle</b>([<i>angle</i>])
+<a name="area_radial_endAngle" href="SVG-Shapes.md#area_radial_endAngle">#</a> area.<b>endAngle</b>([<i>angle</i>])
 
 …
 
-<a name="arc" href="SVG-Shapes#arc">#</a> d3.svg.<b>arc</b>()
+<a name="arc" href="SVG-Shapes.md#arc">#</a> d3.svg.<b>arc</b>()
 
 Constructs a new arc generator with the default inner radius, outer radius, start angle and end angle accessor functions (that assume the input data is an object with named attributes matching the accessors; see below for details). While the default accessors assume that the arc dimensions are all specified dynamically, it is very common to set one or more of the dimensions as a constant, such as setting the inner radius to zero for a pie chart. The returned function generates path data for a closed solid arc, as in a pie or donut chart:
 
@@ -403,11 +403,11 @@ Constructs a new arc generator with the default inner radius, outer radius, star
 
 In fact, four forms are possible: a [disk](https://en.wikipedia.org/wiki/Disk_(mathematics)) (when the inner radius is zero and the angular span is greater than or equal to 2π), a [circular sector](http://en.wikipedia.org/wiki/Circular_sector) (when the inner radius is zero and the angular span is less than 2π), an [annulus](http://en.wikipedia.org/wiki/Annulus_(mathematics)) (when the inner radius is non-zero and the angular span is greater than or equal to 2π), and an annular sector (when the inner radius is non-zero and the angular span is less than 2π).
 
-<a name="_arc" href="SVG-Shapes#_arc">#</a> <b>arc</b>(<i>datum</i>[, <i>index</i>])
+<a name="_arc" href="SVG-Shapes.md#_arc">#</a> <b>arc</b>(<i>datum</i>[, <i>index</i>])
 
 Returns the path data string for the specified *datum*. An optional *index* may be specified, which is passed through to the arc's accessor functions.
 
-<a name="arc_innerRadius" href="SVG-Shapes#arc_innerRadius">#</a> arc.<b>innerRadius</b>([<i>radius</i>])
+<a name="arc_innerRadius" href="SVG-Shapes.md#arc_innerRadius">#</a> arc.<b>innerRadius</b>([<i>radius</i>])
 
 If *radius* is specified, sets the inner radius accessor to the specified function or constant. If *radius* is not specified, returns the current inner radius accessor, which defaults to:
 
@@ -419,7 +419,7 @@ function innerRadius(d) {
 
 The arc generator arguments (typically `d` and `i`) and context (`this`) are passed through to the accessor function. An inner radius accessor function is useful for handling data in a different format or for applying a [quantitative scale](Quantitative Scales) to encode data. A constant inner radius may be used to create a standard pie or donut chart.
 
-<a name="arc_outerRadius" href="SVG-Shapes#arc_outerRadius">#</a> arc.<b>outerRadius</b>([<i>radius</i>])
+<a name="arc_outerRadius" href="SVG-Shapes.md#arc_outerRadius">#</a> arc.<b>outerRadius</b>([<i>radius</i>])
 
 If *radius* is specified, sets the outer radius accessor to the specified function or constant. If *radius* is not specified, returns the current outer radius accessor, which defaults to:
 
@@ -451,7 +451,7 @@ The pad radius is the radius at which the [pad angle](#arc_padAngle) is applied:
 
 If the pad radius is specified as an accessor function, the arc generator arguments (typically `d` and `i`) and context (`this`) are passed through to the accessor function.
 
-<a name="arc_startAngle" href="SVG-Shapes#arc_startAngle">#</a> arc.<b>startAngle</b>([<i>angle</i>])
+<a name="arc_startAngle" href="SVG-Shapes.md#arc_startAngle">#</a> arc.<b>startAngle</b>([<i>angle</i>])
 
 If *angle* is specified, sets the start angle accessor to the specified function or constant. If *angle* is not specified, returns the current start angle accessor, which defaults to:
 
@@ -465,7 +465,7 @@ Angles are specified in radians; 0 corresponds to 12 o’clock (negative *y*) an
 
 For constructing pie or donut charts, you will need to compute the start angle of each arc as the end angle of the previous arc. This can be done conveniently using the [pie layout](Pie-Layout.md), which takes an array of input data and returns arc objects with `startAngle` and `endAngle` attributes compatible with the default arc accessors.
 
-<a name="arc_endAngle" href="SVG-Shapes#arc_endAngle">#</a> arc.<b>endAngle</b>([<i>angle</i>])
+<a name="arc_endAngle" href="SVG-Shapes.md#arc_endAngle">#</a> arc.<b>endAngle</b>([<i>angle</i>])
 
 If *angle* is specified, sets the end angle accessor to the specified function or constant. If *angle* is not specified, returns the current end angle accessor, which defaults to:
 
@@ -493,7 +493,7 @@ Angles are specified in radians. If the pad angle is specified as an accessor fu
 
 Although the pad angle can be specified as a constant, it is preferable to use the default pad angle accessor and instead use [pie.padAngle](Pie-Layout.md#padAngle) to compute the appropriate pad angle, and to recompute the start and end angles of each arc so as to preserve approximate relative areas.
 
-<a name="arc_centroid" href="SVG-Shapes#arc_centroid">#</a> arc.<b>centroid</b>(<i>arguments…</i>)
+<a name="arc_centroid" href="SVG-Shapes.md#arc_centroid">#</a> arc.<b>centroid</b>(<i>arguments…</i>)
 
 Computes the centroid of the arc that would be generated from the specified input *arguments*; typically, the arguments are the current datum (d), and optionally the current index (i). The centroid is defined as the midpoint in polar coordinates of the inner and outer radius, and the start and end angle. This provides a convenient location for arc labels. For example:
 
@@ -507,7 +507,7 @@ arcs.append("text")
 
 Alternatively, you can use SVG's transform attribute to rotate text into position, though you may need to convert radians back into degrees. Yet another possibility is to use a [textPath](http://www.w3.org/TR/SVG/text.html#TextPathElement) element to curve the label along the path of the arc!
 
-<a name="symbol" href="SVG-Shapes#symbol">#</a> d3.svg.<b>symbol</b>()
+<a name="symbol" href="SVG-Shapes.md#symbol">#</a> d3.svg.<b>symbol</b>()
 
 Constructs a new symbol generator with the default *type*- and *size*-accessor functions (that make no assumptions about input data, and produce a circle sized 64 square pixels; see below for details). While the default accessors generate static symbols, it is common to set one or more of the accessors using a function, such as setting the size proportional to a dimension of data for a scatterplot. The returned function generates path data for various symbols, as in a dot plot:
 
@@ -525,11 +525,11 @@ vis.selectAll("path")
 
 In the future, we may add *x*- and *y*-accessors for parity with the line and area generators. The symbol will be centered at the origin (0,0) of the local coordinate system. You can also use SVG's built-in basic shapes to produce many of these symbol types, though D3's symbol generator is useful in conjunction with path elements because you can easily change the symbol type and size as a function of data.
 
-<a name="_symbol" href="SVG-Shapes#_symbol">#</a> <b>symbol</b>(<i>datum</i>[, <i>index</i>])
+<a name="_symbol" href="SVG-Shapes.md#_symbol">#</a> <b>symbol</b>(<i>datum</i>[, <i>index</i>])
 
 Returns the path data string for the specified *datum*. An optional *index* may be specified, which is passed through to the symbol's accessor functions.
 
-<a name="symbol_type" href="SVG-Shapes#symbol_type">#</a> symbol.<b>type</b>([<i>type</i>])
+<a name="symbol_type" href="SVG-Shapes.md#symbol_type">#</a> symbol.<b>type</b>([<i>type</i>])
 
 If *type* is specified, sets the *type*-accessor to the specified function or constant. If *type* is not specified, returns the current *type*-accessor. The default accessor is the constant "circle", and the following types are supported:
 
@@ -544,15 +544,15 @@ Types are normalized to have the same area in square pixels, according to the sp
 
 The *type*-accessor is invoked in the same manner as other value functions in D3. The *this* context of the function is the current element in the selection. (Technically, the same *this* context that invokes the arc function; however, in the common case that the symbol generator is passed to the [attr](Selections.md#attr) operator, the *this* context will be the associated DOM element.) The function is passed two arguments, the current datum (d) and the current index (i). It is also possible to specify the *type*-accessor as a constant rather than a function.
 
-<a name="symbol_size" href="SVG-Shapes#symbol_size">#</a> symbol.<b>size</b>([<i>size</i>])
+<a name="symbol_size" href="SVG-Shapes.md#symbol_size">#</a> symbol.<b>size</b>([<i>size</i>])
 
 If *size* is specified, sets the *size*-accessor to the specified function or constant in square pixels. If *size* is not specified, returns the current *size*-accessor.  The default is 64. This accessor is invoked on the argument passed to the symbol generator. Typically, a *size*-accessor is specified as a function when you want the size of the symbol to encode a [quantitative dimension](Quantitative-Scales.md) of data, or a constant it you simply want to make all the dots bigger or smaller. If you want to specify a radius rather than the size, you must do so indirectly, for example using a [pow](Quantitative-Scales.md#pow) scale with exponent 2.
 
-<a name="symbolTypes" href="SVG-Shapes#symbolTypes">#</a> d3.svg.<b>symbolTypes</b>
+<a name="symbolTypes" href="SVG-Shapes.md#symbolTypes">#</a> d3.svg.<b>symbolTypes</b>
 
 The array of supported [symbol types](#symbol_type).
 
-<a name="chord" href="SVG-Shapes#chord">#</a> d3.svg.<b>chord</b>()
+<a name="chord" href="SVG-Shapes.md#chord">#</a> d3.svg.<b>chord</b>()
 
 Constructs a new chord generator with the default accessor functions (that assume the input data is an object with named attributes matching the accessors; see below for details). While the default accessors assume that the chord dimensions are all specified dynamically, it is very common to set one or more of the dimensions as a constant, such as the radius. The returned function generates path data for a closed shape connecting two [arcs](http://en.wikipedia.org/wiki/Arc_(geometry)) with quadratic Bézier curves, as in a [chord diagram](http://mbostock.github.com/d3/ex/chord.html):
 
@@ -560,11 +560,11 @@ Constructs a new chord generator with the default accessor functions (that assum
 
 A chord generator is often used in conjunction with an [arc generator](SVG-Shapes.md#arc), so as to draw annular segments at the start and end of the chords. In addition, the [chord layout](Chord-Layout.md) is useful for generating objects that describe a set of grouped chords from a matrix, compatible with the default accessors.
 
-<a name="_chord" href="SVG-Shapes#_chord">#</a> <b>chord</b>(<i>datum</i>[, <i>index</i>])
+<a name="_chord" href="SVG-Shapes.md#_chord">#</a> <b>chord</b>(<i>datum</i>[, <i>index</i>])
 
 Returns the path data string for the specified *datum*. An optional *index* may be specified, which is passed through to the chord's accessor functions.
 
-<a name="chord_source" href="SVG-Shapes#chord_source">#</a> chord.<b>source</b>([<i>source</i>])
+<a name="chord_source" href="SVG-Shapes.md#chord_source">#</a> chord.<b>source</b>([<i>source</i>])
 
 If *source* is specified, sets the *source*-accessor to the specified function or constant. If *source* is not specified, returns the current *source*-accessor. The purpose of the *source* accessor is to return an object that describes the starting arc of the chord. The returned object is subsequently passed to the [radius](SVG-Shapes.md#chord_radius), [startAngle](SVG-Shapes.md#chord_startAngle) and [endAngle](SVG-Shapes.md#chord_endAngle) accessors. This allows these other accessors to be reused for both the source and target arc descriptions. The default accessor assumes that the input data is an object with suitably-named attributes:
 
@@ -576,7 +576,7 @@ function source(d) {
 
 The *source*-accessor is invoked in the same manner as other value functions in D3. The *this* context of the function is the current element in the selection. (Technically, the same *this* context that invokes the arc function; however, in the common case that the symbol generator is passed to the [attr](Selections.md#attr) operator, the *this* context will be the associated DOM element.) The function is passed two arguments, the current datum (d) and the current index (i). It is also possible to specify the *source*-accessor as a constant rather than a function.
 
-<a name="chord_target" href="SVG-Shapes#chord_target">#</a> chord.<b>target</b>([<i>target</i>])
+<a name="chord_target" href="SVG-Shapes.md#chord_target">#</a> chord.<b>target</b>([<i>target</i>])
 
 If *target* is specified, sets the *target*-accessor to the specified function or constant. If *target* is not specified, returns the current *target*-accessor. The purpose of the *target* accessor is to return an object that describes the ending arc of the chord. The returned object is subsequently passed to the [radius](SVG-Shapes.md#chord_radius), [startAngle](SVG-Shapes.md#chord_startAngle) and [endAngle](SVG-Shapes.md#chord_endAngle) accessors. This allows these other accessors to be reused for both the source and target arc descriptions. The default accessor assumes that the input data is an object with suitably-named attributes:
 
@@ -588,7 +588,7 @@ function target(d) {
 
 The *target*-accessor is invoked in the same manner as other value functions in D3. The function is passed two arguments, the current datum (d) and the current index (i). It is also possible to specify the *target*-accessor as a constant rather than a function.
 
-<a name="chord_radius" href="SVG-Shapes#chord_radius">#</a> chord.<b>radius</b>([<i>radius</i>])
+<a name="chord_radius" href="SVG-Shapes.md#chord_radius">#</a> chord.<b>radius</b>([<i>radius</i>])
 
 If *radius* is specified, sets the *radius*-accessor to the specified function or constant. If *radius* is not specified, returns the current *radius*-accessor. The default accessor assumes that the input source or target description is an object with suitably-named attributes:
 
@@ -600,7 +600,7 @@ function radius(d) {
 
 The *radius*-accessor is invoked in a similar manner as other value functions in D3. The function is passed two arguments, the current source description (derived from the current datum, d) and the current index (i). It is also possible to specify the *radius*-accessor as a constant rather than a function.
 
-<a name="chord_startAngle" href="SVG-Shapes#chord_startAngle">#</a> chord.<b>startAngle</b>([<i>angle</i>])
+<a name="chord_startAngle" href="SVG-Shapes.md#chord_startAngle">#</a> chord.<b>startAngle</b>([<i>angle</i>])
 
 If *startAngle* is specified, sets the *startAngle*-accessor to the specified function or constant. If *startAngle* is not specified, returns the current *startAngle*-accessor. Angles are specified in radians; 0 corresponds to 12 o’clock (negative *y*) and proceeds clockwise, repeating at 2π. The default accessor assumes that the input source or target description is an object with suitably-named attributes:
 
@@ -612,7 +612,7 @@ function startAngle(d) {
 
 The *startAngle*-accessor is invoked in a similar manner as other value functions in D3. The function is passed two arguments, the current source or target description (derived from the current datum, d) and the current index (i). It is also possible to specify the *startAngle*-accessor as a constant rather than a function.
 
-<a name="chord_endAngle" href="SVG-Shapes#chord_endAngle">#</a> chord.<b>endAngle</b>([<i>angle</i>])
+<a name="chord_endAngle" href="SVG-Shapes.md#chord_endAngle">#</a> chord.<b>endAngle</b>([<i>angle</i>])
 
 If *endAngle* is specified, sets the *endAngle*-accessor to the specified function or constant. If *endAngle* is not specified, returns the current *endAngle*-accessor. Angles are specified in radians; 0 corresponds to 12 o’clock (negative *y*) and proceeds clockwise, repeating at 2π. The default accessor assumes that the input source or target description is an object with suitably-named attributes:
 
@@ -624,7 +624,7 @@ function endAngle(d) {
 
 The *endAngle*-accessor is invoked in a similar manner as other value functions in D3. The function is passed two arguments, the current source or target description (derived from the current datum, d) and the current index (i). It is also possible to specify the *endAngle*-accessor as a constant rather than a function.
 
-<a name="diagonal" href="SVG-Shapes#diagonal">#</a> d3.svg.<b>diagonal</b>()
+<a name="diagonal" href="SVG-Shapes.md#diagonal">#</a> d3.svg.<b>diagonal</b>()
 
 Constructs a new diagonal generator with the default accessor functions (that assume the input data is an object with named attributes matching the accessors; see below for details). The returned function generates the path data for a cubic Bézier connecting the source and target points; the tangents are specified to produce smooth fan-in and fan-out when connecting nodes, as in a [node-link diagram](http://mbostock.github.com/d3/ex/tree.html):
 
@@ -632,11 +632,11 @@ Constructs a new diagonal generator with the default accessor functions (that as
 
 Although diagonals default to Cartesian (axis-aligned) orientations, they can be used in radial and other orientations using a [projection](SVG-Shapes.md#diagonal_projection).
 
-<a name="_diagonal" href="SVG-Shapes#_diagonal">#</a> <b>diagonal</b>(<i>datum</i>[, <i>index</i>])
+<a name="_diagonal" href="SVG-Shapes.md#_diagonal">#</a> <b>diagonal</b>(<i>datum</i>[, <i>index</i>])
 
 Returns the path data string for the specified *datum*. An optional *index* may be specified, which is passed through to the diagonal's accessor functions.
 
-<a name="diagonal_source" href="SVG-Shapes#diagonal_source">#</a> diagonal.<b>source</b>([<i>source</i>])
+<a name="diagonal_source" href="SVG-Shapes.md#diagonal_source">#</a> diagonal.<b>source</b>([<i>source</i>])
 
 If *source* is specified, sets the *source*-accessor to the specified function or constant. If *source* is not specified, returns the current *source*-accessor. The purpose of the *source* accessor is to return an object of the form `{x, y}` that describes the starting point of the diagonal. (The returned object is subsequently passed to the [projection](SVG-Shapes.md#diagonal_projection).) The default accessor assumes that the input data is an object with suitably-named attributes:
 
@@ -648,7 +648,7 @@ function source(d) {
 
 The *source*-accessor is invoked in the same manner as other value functions in D3. The *this* context of the function is the current element in the selection. (Technically, the same *this* context that invokes the diagonal function; however, in the common case that the symbol generator is passed to the [attr](Selections.md#attr) operator, the *this* context will be the associated DOM element.) The function is passed two arguments, the current datum (d) and the current index (i). It is also possible to specify the *source*-accessor as a constant rather than a function.
 
-<a name="diagonal_target" href="SVG-Shapes#diagonal_target">#</a> diagonal.<b>target</b>([<i>target</i>])
+<a name="diagonal_target" href="SVG-Shapes.md#diagonal_target">#</a> diagonal.<b>target</b>([<i>target</i>])
 
 If *target* is specified, sets the *target*-accessor to the specified function or constant. If *target* is not specified, returns the current *target*-accessor. The purpose of the *target* accessor is to return an object of the form `{x, y}` that describes the ending point of the diagonal. (The returned object is subsequently passed to the [projection](SVG-Shapes.md#diagonal_projection).) The default accessor assumes that the input data is an object with suitably-named attributes:
 
@@ -660,7 +660,7 @@ function target(d) {
 
 The *target*-accessor is invoked in the same manner as other value functions in D3. The function is passed two arguments, the current datum (d) and the current index (i). It is also possible to specify the *source*-accessor as a constant rather than a function.
 
-<a name="diagonal_projection" href="SVG-Shapes#diagonal_projection">#</a> diagonal.<b>projection</b>([<i>projection</i>])
+<a name="diagonal_projection" href="SVG-Shapes.md#diagonal_projection">#</a> diagonal.<b>projection</b>([<i>projection</i>])
 
 If *projection* is specified, sets the *projection* to the specified function. If *projection* is not specified, returns the current *projection*. The *projection* converts a point (such as that returned by the source and target accessors) of the form `{x, y}` to a two-element array of numbers. The default accessor assumes that the input point is an object with *x* and *y* attributes:
 
@@ -681,10 +681,10 @@ function projection(d) {
 
 The *projection* is invoked in a similar manner as other value functions in D3. The function is passed two arguments, the current source or target point (derived from the current data, d) and the current index (i).
 
-<a name="diagonal_radial" href="SVG-Shapes#diagonal_radial">#</a> d3.svg.diagonal.<b>radial</b>()
+<a name="diagonal_radial" href="SVG-Shapes.md#diagonal_radial">#</a> d3.svg.diagonal.<b>radial</b>()
 
 …
 
-<a name="_diagonal_radial" href="SVG-Shapes#_diagonal_radial">#</a> <b>diagonal</b>(<i>datum</i>[, <i>index</i>])
+<a name="_diagonal_radial" href="SVG-Shapes.md#_diagonal_radial">#</a> <b>diagonal</b>(<i>datum</i>[, <i>index</i>])
 
 Returns the path data string for the specified *datum*. An optional *index* may be specified, which is passed through to the diagonal's accessor functions.

--- a/Selections.md
+++ b/Selections.md
@@ -12,19 +12,19 @@ You won't generally need to use `for` loops or recursive functions to modify the
 
 D3 provides two top-level methods for selecting elements: [select](Selections.md#d3_select) and [selectAll](Selections.md#d3_selectAll). These methods accept selector strings; the former selects only the first matching element, while the latter selects *all* matching elements in document traversal order. These methods can also accept nodes, which is useful for integration with third-party libraries such as jQuery or developer tools (`$0`).
 
-<a name="d3_select" href="Selections#d3_select">#</a> d3.<b>select</b>(<i>selector</i>)
+<a name="d3_select" href="Selections.md#d3_select">#</a> d3.<b>select</b>(<i>selector</i>)
 
 Selects the first element that matches the specified selector string, returning a single-element selection. If no elements in the current document match the specified selector, returns the empty selection. If multiple elements match the selector, only the first matching element (in document traversal order) will be selected.
 
-<a href="Selections#d3_select">#</a> d3.<b>select</b>(<i>node</i>)
+<a href="Selections.md#d3_select">#</a> d3.<b>select</b>(<i>node</i>)
 
 Selects the specified node. This is useful if you already have a reference to a node, such as `d3.select(this)` within an event listener, or a global such as `document.body`. This function does not traverse the DOM.
 
-<a name="d3_selectAll" href="Selections#d3_selectAll">#</a> d3.<b>selectAll</b>(<i>selector</i>)
+<a name="d3_selectAll" href="Selections.md#d3_selectAll">#</a> d3.<b>selectAll</b>(<i>selector</i>)
 
 Selects all elements that match the specified selector. The elements will be selected in document traversal order (top-to-bottom). If no elements in the current document match the specified selector, returns the empty selection.
 
-<a href="Selections#d3_selectAll">#</a> d3.<b>selectAll</b>(<i>nodes</i>)
+<a href="Selections.md#d3_selectAll">#</a> d3.<b>selectAll</b>(<i>nodes</i>)
 
 Selects the specified array of elements. This is useful if you already have a reference to nodes, such as `d3.selectAll(this.childNodes)` within an event listener, or a global such as `document.links`. The *nodes* argument doesn't have to be an array, exactly; any pseudo-array that can be coerced into an array (e.g., a `NodeList` or `arguments`) will work. This function does not traverse the DOM.
 
@@ -38,7 +38,7 @@ If you want to learn how selections work, try selecting elements interactively u
 
 D3 has a variety of operators which affect the document content. These are what you'll use the most to display data! When used to set document content, the operators return the current selection, so you can chain multiple operators together in a concise statement.
 
-<a name="attr" href="Selections#attr">#</a> selection.<b>attr</b>(<i>name</i>[, <i>value</i>])
+<a name="attr" href="Selections.md#attr">#</a> selection.<b>attr</b>(<i>name</i>[, <i>value</i>])
 
 If *value* is specified, sets the attribute with the specified name to the specified value on all selected elements. If *value* is a constant, then all elements are given the same attribute value; otherwise, if *value* is a function, then the function is evaluated for each selected element (in order), being passed the current datum `d` and the current index `i`, with the `this` context as the current DOM element. The function's return value is then used to set each element's attribute. A null value will remove the specified attribute.
 
@@ -48,7 +48,7 @@ The specified *name* may have a namespace prefix, such as `xlink:href`, to speci
 
 *name* can also be an Object of *name* and *value* attributes.
 
-<a name="classed" href="Selections#classed">#</a> selection.<b>classed</b>(<i>name</i>[, <i>value</i>])
+<a name="classed" href="Selections.md#classed">#</a> selection.<b>classed</b>(<i>name</i>[, <i>value</i>])
 
 This operator is a convenience routine for setting the "class" attribute; it understands that the "class" attribute is a set of tokens separated by spaces. Under the hood, it will use the [classList](https://developer.mozilla.org/en/DOM/element.classList "https://developer.mozilla.org/en/DOM/element.classList") if available, for convenient adding, removing and toggling of CSS classes.
 
@@ -58,7 +58,7 @@ If you want to set several classes at once, use an object literal like so: `sele
 
 If *value* is not specified, returns true if and only if the first non-null element in this selection has the specified class. This is generally useful only if you know the selection contains exactly one element.
 
-<a name="style" href="Selections#style">#</a> selection.<b>style</b>(<i>name</i>[, <i>value</i>[, <i>priority</i>]])
+<a name="style" href="Selections.md#style">#</a> selection.<b>style</b>(<i>name</i>[, <i>value</i>[, <i>priority</i>]])
 
 If *value* is specified, sets the CSS style property with the specified name to the specified value on all selected elements. If *value* is a constant, then all elements are given the same style value; otherwise, if *value* is a function, then the function is evaluated for each selected element (in order), being passed the current datum `d` and the current index `i`, with the `this` context as the current DOM element. The function's return value is then used to set each element's style property. A null value will remove the style property. An optional *priority* may also be specified, either as null or the string "important" (without the exclamation point).
 
@@ -72,7 +72,7 @@ Note that CSS styles typically have associated units. For example, `"3px"` is a 
 
 If *value* is not specified, returns the current *computed* value of the specified style property for the first non-null element in the selection. This is generally useful only if you know the selection contains exactly one element. Note that the computed value may be *different* than the value that was previously set, particularly if the style property was set using a shorthand property (such as the "font" style, which is shorthand for "font-size", "font-face", etc.).
 
-<a name="property" href="Selections#property">#</a> selection.<b>property</b>(<i>name</i>[, <i>value</i>])
+<a name="property" href="Selections.md#property">#</a> selection.<b>property</b>(<i>name</i>[, <i>value</i>])
 
 Some HTML elements have special properties that are not addressable using standard attributes or styles. For example, form text fields have a `value` string property, and checkboxes have a `checked` boolean property. You can use the `property` operator to get or set these properties, or any other addressable field on the underlying element, such as `className`.
 
@@ -82,7 +82,7 @@ If you want to set several properties at once, use an object literal like so: `s
 
 If *value* is not specified, returns the value of the specified property for the first non-null element in the selection. This is generally useful only if you know the selection contains exactly one element.
 
-<a name="text" href="Selections#text">#</a> selection.<b>text</b>([<i>value</i>])
+<a name="text" href="Selections.md#text">#</a> selection.<b>text</b>([<i>value</i>])
 
 The `text` operator is based on the [textContent](http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-textContent "http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-textContent") property; setting the text content will replace any existing child elements.
 
@@ -90,7 +90,7 @@ If *value* is specified, sets the text content to the specified value on all sel
 
 If *value* is not specified, returns the text content for the first non-null element in the selection. This is generally useful only if you know the selection contains exactly one element.
 
-<a name="html" href="Selections#html">#</a> selection.<b>html</b>([<i>value</i>])
+<a name="html" href="Selections.md#html">#</a> selection.<b>html</b>([<i>value</i>])
 
 The `html` operator is based on the [innerHTML](http://dev.w3.org/html5/spec-LC/apis-in-html-documents.html#innerhtml "http://dev.w3.org/html5/spec-LC/apis-in-html-documents.html#innerhtml") property; setting the inner HTML content will replace any existing child elements. Also, you may prefer to use the `append` or `insert` operators to create HTML content in a data-driven way; this operator is intended for when you want a little bit of HTML, say for rich formatting.
 
@@ -100,7 +100,7 @@ If *value* is not specified, returns the inner HTML content for the first non-nu
 
 Note: as its name suggests, selection.html is only supported on HTML elements. SVG elements and other non-HTML elements do not support the innerHTML property, and thus are incompatible with selection.html. Consider using [XMLSerializer](https://developer.mozilla.org/en-US/docs/XMLSerializer) to convert a DOM subtree to text. See also the [innersvg polyfill](https://code.google.com/p/innersvg/), which provides a shim to support the innerHTML property on SVG elements.
 
-<a name="append" href="Selections#append">#</a> selection.<b>append</b>(<i>name</i>)
+<a name="append" href="Selections.md#append">#</a> selection.<b>append</b>(<i>name</i>)
 
 Appends a new element with the specified *name* as the last child of each element in the current selection, returning a new selection containing the appended elements. Each new element inherits the data of the current elements, if any, in the same manner as [select](Selections.md#select) for subselections.
 
@@ -112,7 +112,7 @@ selection.enter().append(function(d) {
 ```
 When the *name* is specified as a string, it may have a namespace prefix of the form "namespace:tag". For example, "svg:text" will create a "text" element in the SVG namespace. By default, D3 supports svg, xhtml, xlink, xml and xmlns namespaces. Additional namespaces can be registered by adding to [d3.ns.prefix](Namespaces.md#prefix). If no namespace is specified, then the namespace will be inherited from the enclosing element; or, if the name is one of the known prefixes, the corresponding namespace will be used (for example, "svg" implies "svg:svg").
 
-<a name="insert" href="Selections#insert">#</a> selection.<b>insert</b>(<i>name</i>[, <i>before</i>])
+<a name="insert" href="Selections.md#insert">#</a> selection.<b>insert</b>(<i>name</i>[, <i>before</i>])
 
 Inserts a new element with the specified *name* before the element matching the specified *before* selector, for each element in the current selection, returning a new selection containing the inserted elements. If the before selector does not match any elements, then the new element will be the last child as with [append](Selections.md#append). Each new element inherits the data of the current elements (if any), in the same manner as [select](Selections.md#select) for subselections.
 
@@ -120,13 +120,13 @@ The *name* may be specified either as a constant string or as a function that re
 
 Likewise, the *before* selector may be specified as a selector string or a function which returns a DOM element. For instance, `insert("div", ":first-child")` will prepend child div nodes to the current selection. For [enter selections](Selections.md#enter), the *before* selector may be omitted, in which case entering elements will be inserted immediately before the next following sibling in the update selection, if any. This allows you to insert elements into the DOM in an order consistent with bound data. Note, however, the slower [selection.order](Selections.md#order) may still be required if updating elements change order.
 
-<a name="remove" href="Selections#remove">#</a> selection.<b>remove</b>()
+<a name="remove" href="Selections.md#remove">#</a> selection.<b>remove</b>()
 
 Removes the elements in the current selection from the current document. Returns the current selection (the same elements that were removed) which are now “off-screen”, detached from the DOM. Note that there is not currently a dedicated API to add removed elements back to the document; however, you can pass a function to selection.append or selection.insert to re-add elements.
 
 ### Data
 
-<a name="data" href="Selections#data">#</a> selection.<b>data</b>([<i>values</i>[, <i>key</i>]])
+<a name="data" href="Selections.md#data">#</a> selection.<b>data</b>([<i>values</i>[, <i>key</i>]])
 
 Joins the specified array of data with the current selection. The specified *values* is an array of data values (e.g. numbers or objects), or a function that returns an array of values. If a *key* function is not specified, then the first datum in *values* is assigned to the first element in the current selection, the second datum to the second selected element, and so on. When data is assigned to an element, it is stored in the property `__data__` (defined by D3), thus making the data "sticky" so that it is available on re-selection.
 
@@ -167,7 +167,7 @@ If *values* is not specified, then this method returns the array of data for the
 
 Note: the `data` method cannot be used to clear previously-bound data; use [selection.datum](#datum) instead.
 
-<a name="enter" href="Selections#enter">#</a> selection.<b>enter()</b>
+<a name="enter" href="Selections.md#enter">#</a> selection.<b>enter()</b>
 
 Returns the enter selection: placeholder nodes for each data element for which no corresponding existing DOM element was found in the current selection. This method is only defined on the update selection, which is returned by the [data](Selections.md#data) operator. In addition, the enter selection only defines the [append](Selections.md#append), [insert](Selections.md#insert), [select](Selections.md#select) and [call](Selections.md#call) operators; you must use these operators to instantiate the entering elements before modifying any content. Enter selections also support [empty](Selections.md#empty) and [size](Selections.md#size).
 
@@ -203,7 +203,7 @@ update_sel.attr(/* operate on old and new elements */)
 update_sel.exit().remove() /* complete the enter-update-exit pattern */
 ```
 
-<a name="exit" href="Selections#exit">#</a> selection.<b>exit()</b>
+<a name="exit" href="Selections.md#exit">#</a> selection.<b>exit()</b>
 
 Returns the exit selection: existing DOM elements in the current selection for which no new data element was found. This method is only defined on the update selection, which is returned by the [data](Selections.md#data) operator. The exit selection defines all the normal operators, though typically the main one you'll want to use is [remove](Selections.md#remove); the other operators exist primarily so you can define an exiting transition as desired. Note that the *exit* operator merely returns a reference to the exit selection, and it is up to you to remove the new nodes.
 
@@ -257,7 +257,7 @@ This would result in:
 
 If you want the document traversal order to match the selection data order, you can use [sort](#sort) or [order](#order).
 
-<a name="filter" href="Selections#filter">#</a> selection.<b>filter</b>(<i>selector</i>)
+<a name="filter" href="Selections.md#filter">#</a> selection.<b>filter</b>(<i>selector</i>)
 
 Filters the selection, returning a new selection that contains only the elements for which the specified *selector* is true. The *selector* may be specified either as a function or as a selector string, such as ".foo". As with other operators, the function is passed the current datum `d` and index `i`, with the `this` context as the current DOM element. Filter should only be called on selections with DOM elements bound, e.g. from [append](Selections.md#append) or [insert](Selections.md#insert). To bind elements to only a subset of the data, call the built-in array [filter](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/Filter "https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/Filter") on the argument to [data](Selections.md#data). Like the built-in function, D3's filter *does not* preserve the index of the original selection in the returned selection; it returns a copy with elements removed. If you want to preserve the index, use [select](Selections.md#select) instead.
 
@@ -281,7 +281,7 @@ var odds = selection.filter(":nth-child(even)");
 
 Thus, you can use either select or filter to apply operators to a subset of elements.
 
-<a name="datum" href="Selections#datum">#</a> selection.<b>datum</b>([<i>value</i>])
+<a name="datum" href="Selections.md#datum">#</a> selection.<b>datum</b>([<i>value</i>])
 
 Gets or sets the bound data for each selected element. Unlike the [selection.data](#data) method, this method does not compute a join (and thus does not compute enter and exit selections). This method is implemented on top of [selection.property](#property):
 
@@ -342,7 +342,7 @@ If *listener* is not specified, returns the currently-assigned listener for the 
 
 Note that while listeners will always see the latest datum (`d`) for their element, the index (`i`) is a property of the selection, and is defined when the selection is created. Updating the index requires re-selecting and re-binding listeners.
 
-<a name="d3_event" href="Selections#d3_event">#</a> d3.<b>event</b>
+<a name="d3_event" href="Selections.md#d3_event">#</a> d3.<b>event</b>
 
 Stores the current event, if any. This global is registered during an event listener callback with the [on](Selections.md#on) operator. The current event is reset after the listener is notified in a `finally` block. This allows the listener function to have the same form as other operator functions, being passed the current datum `d` and index `i`.
 
@@ -360,7 +360,7 @@ Returns the *x* and *y* coordinates of the touch with the specified identifier a
 
 Returns the *x* and *y* coordinates of each touch associated with the current [d3.event](#d3_event), based on the [touches](http://developer.apple.com/library/safari/documentation/UserExperience/Reference/TouchEventClassReference/TouchEvent/TouchEvent.html#//apple_ref/javascript/instp/TouchEvent/touches "http://developer.apple.com/library/safari/documentation/UserExperience/Reference/TouchEventClassReference/TouchEvent/TouchEvent.html#//apple_ref/javascript/instp/TouchEvent/touches") attribute, relative to the specified *container*. The container may be an HTML or SVG container element, such as an svg:g or svg:svg. The coordinates are returned as an array of two-element arrays [ [ *x1*, *y1*], [ *x2*, *y2*], … ]. If *touches* is specified, returns the positions of the specified touches; if *touches* is not specified, it defaults to the `touches` property on the current event.
 
-<a name="transition" href="Selections#transition">#</a> selection.<b>transition</b>([<i>name</i>])
+<a name="transition" href="Selections.md#transition">#</a> selection.<b>transition</b>([<i>name</i>])
 
 Starts a [transition](Transitions.md) for the current selection. Transitions behave much like selections, except operators animate smoothly over time rather than applying instantaneously.
 
@@ -380,13 +380,13 @@ selection
 
 Whereas the top-level select methods query the entire document, a selection's [select](Selections.md#select) and [selectAll](Selections.md#selectAll) operators restrict queries to descendants of each selected element; we call this "subselection". For example, `d3.selectAll("p").select("b")` returns the first bold ("b") elements in every paragraph ("p") element. Subselecting via selectAll groups elements by ancestor. Thus, `d3.selectAll("p").selectAll("b")` groups by paragraph, while `d3.selectAll("p b")` returns a flat selection. Subselecting via select is similar, but preserves groups and propagates data. Grouping plays an important role in the data join, and functional operators may depend on the numeric index of the current element within its group.
 
-<a name="select" href="Selections#select">#</a> selection.<b>select</b>(<i>selector</i>)
+<a name="select" href="Selections.md#select">#</a> selection.<b>select</b>(<i>selector</i>)
 
 For each element in the current selection, selects the first descendant element that matches the specified *selector* string. If no element matches the specified selector for the current element, the element at the current index will be null in the returned selection; operators (with the exception of [data](Selections.md#data)) automatically skip null elements, thereby preserving the index of the existing selection. If the current element has associated data, this data is inherited by the returned subselection, and automatically bound to the newly selected elements. If multiple elements match the selector, only the first matching element in document traversal order will be selected.
 
 The *selector* may also be specified as a function that returns an element, or null if there is no matching element. In this case, the specified *selector* is invoked in the same manner as other operator functions, being passed the current datum `d` and index `i`, with the `this` context as the current DOM element.
 
-<a name="selectAll" href="Selections#selectAll">#</a> selection.<b>selectAll</b>(<i>selector</i>)
+<a name="selectAll" href="Selections.md#selectAll">#</a> selection.<b>selectAll</b>(<i>selector</i>)
 
 For each element in the current selection, selects descendant elements that match the specified *selector* string. The returned selection is grouped by the ancestor node in the current selection. If no element matches the specified selector for the current element, the group at the current index will be empty in the returned selection. The subselection does not inherit data from the current selection; however, if the [data](Selections.md#data) value is specified as a function, this function will be called with the data `d` of the ancestor node and the group index `i` to determine the data bindings for the subselection.
 
@@ -404,11 +404,11 @@ The *selector* may also be specified as a function that returns an array of elem
 
 For advanced usage, D3 has a few additional operators for custom control flow.
 
-<a name="each" href="Selections#each">#</a> selection.<b>each</b>(<i>function</i>)
+<a name="each" href="Selections.md#each">#</a> selection.<b>each</b>(<i>function</i>)
 
 Invokes the specified *function* for each element in the current selection, passing in the current datum `d` and index `i`, with the `this` context of the current DOM element. This operator is used internally by nearly every other operator, and can be used to invoke arbitrary code for each selected element. The each operator can be used to process selections recursively, by using `d3.select(this)` within the callback function.
 
-<a name="call" href="Selections#call">#</a> selection.<b>call</b>(<i>function</i>[, <i>arguments…</i>])
+<a name="call" href="Selections.md#call">#</a> selection.<b>call</b>(<i>function</i>[, <i>arguments…</i>])
 
 Invokes the specified *function* once, passing in the current selection along with any optional *arguments*. The call operator always returns the current selection, regardless of the return value of the specified function. The call operator is identical to invoking a function by hand; but it makes it easier to use method chaining. For example, say we want to set a number of attributes the same way in a number of different places. So we take the code and wrap it in a reusable function:
 
@@ -452,15 +452,15 @@ d3.selectAll("span").call(bar.setText.bind(bar));
 d3.selectAll("span").call(Foo.prototype.setText.bind(bar));
 ```
 
-<a name="empty" href="Selections#empty">#</a> selection.<b>empty</b>()
+<a name="empty" href="Selections.md#empty">#</a> selection.<b>empty</b>()
 
 Returns true if the current selection is empty; a selection is empty if it contains no elements or only null elements.
 
-<a name="node" href="Selections#node">#</a> selection.<b>node</b>()
+<a name="node" href="Selections.md#node">#</a> selection.<b>node</b>()
 
 Returns the first non-null element in the current selection. If the selection is empty, returns null.
 
-<a name="size" href="Selections#size">#</a> selection.<b>size</b>()
+<a name="size" href="Selections.md#size">#</a> selection.<b>size</b>()
 
 Returns the total number of elements in the current selection.
 

--- a/Stack-Layout.md
+++ b/Stack-Layout.md
@@ -10,11 +10,11 @@ Several baseline algorithms are supported, along with sorting heuristics to impr
 
 The stack layout operates in an arbitrary two-dimensional *x* and *y* coordinate space, similar to D3's other layouts, including [tree](Tree-Layout.md). Thus, layers can be stacked vertically, horizontally, or even [radially](http://hint.fm/projects/flickr/). While the "zero" offset is the default, a streamgraph can be generated using the "wiggle" offset, which attempts to minimize change in slope weighted by layer thickness.
 
-<a name="stack" href="Stack-Layout#stack">#</a> d3.layout.<b>stack</b>()
+<a name="stack" href="Stack-Layout.md#stack">#</a> d3.layout.<b>stack</b>()
 
 Constructs a new stack layout with the default offset (zero) and order (null). The returned layout object is both an object and a function. That is: you can call the layout like any other function, and the layout has additional methods that change its behavior. Like other classes in D3, layouts follow the method chaining pattern where setter methods return the layout itself, allowing multiple setters to be invoked in a concise statement.
 
-<a name="_stack" href="Stack-Layout#_stack">#</a> <b>stack</b>(<i>layers</i>[, <i>index</i>])
+<a name="_stack" href="Stack-Layout.md#_stack">#</a> <b>stack</b>(<i>layers</i>[, <i>index</i>])
 
 Computes the *y*-coordinate baseline for each layer in the *layers* array, and then propagates that baseline to the other layers. In the simplest case, *layers* is a two-dimensional array of *point objects*, all having the same length, and each having a vertical  and horizontal ordinate value to define the *y*-thickness of each layer at the given *x*-position.
 
@@ -33,7 +33,7 @@ The last two being physically added onto the point objects if required.
 
 The optional *index* argument is not consumed by the default layout, but is made available to custom [order](Stack-Layout.md#order) and [offset](Stack-Layout.md#offset) objects.
 
-<a name="values" href="Stack-Layout#values">#</a> stack.<b>values</b>([<i>accessor</i>])
+<a name="values" href="Stack-Layout.md#values">#</a> stack.<b>values</b>([<i>accessor</i>])
 
 Specifies how to extract the *points* array from the *layer* elements of the *layers* array; *accessor* is a function which is invoked on each input layer passed to [stack](Stack-Layout.md#_stack), equivalent to calling *layers.map(accessor)* before computing the stack layout. The default values function is the identity function. If *accessor* is not specified, returns the current values accessor.
 
@@ -77,7 +77,7 @@ svg.selectAll("path")
     .text(function(d) { return d.name; });
 ```
 
-<a name="offset" href="Stack-Layout#offset">#</a> stack.<b>offset</b>([<i>offset</i>])
+<a name="offset" href="Stack-Layout.md#offset">#</a> stack.<b>offset</b>([<i>offset</i>])
 
 If *offset* is specified, sets the stack offset algorithm to the specified value. If *offset* is not specified, returns the current offset algorithm. The following string values are supported:
 
@@ -98,7 +98,7 @@ function offset(data) {
 }
 ```
 
-<a name="order" href="Stack-Layout#order">#</a> stack.<b>order</b>([<i>order</i>])
+<a name="order" href="Stack-Layout.md#order">#</a> stack.<b>order</b>([<i>order</i>])
 
 If *order* is specified, sets the stack order to the specified value. If *order* is not specified, returns the current order. The following string values are supported:
 
@@ -116,7 +116,7 @@ function order(data) {
 
 See also [d3.range](Arrays.md#d3_range).
 
-<a name="x" href="Stack-Layout#x">#</a> stack.<b>x</b>([<i>accessor</i>])
+<a name="x" href="Stack-Layout.md#x">#</a> stack.<b>x</b>([<i>accessor</i>])
 
 Specifies how to access the *x*-coordinate of each value’s position. If *accessor* is specified, sets the accessor to the specified function. If *accessor* is not specified, returns the current function, which by default assumes that each input value has an x attribute:
 
@@ -130,7 +130,7 @@ The *x*-accessor is invoked for each input value, for each input layer, being pa
 
 The *x*-coordinate only affects the behavior of the “wiggle” [offset](#offset); changing this accessor does *not* affect how data is grouped into stacks. Although the *x*-accessor is invoked for all layers (not just the bottommost layer), **the stack layout assumes that the *x*-coordinates of all layers are homogenous and consistent**. In other words, each layer must contain the same number of values, at the same *x*-coordinates, in the same order. If your data is irregular, you will need to reinterpolate or reorder the data before computing the stack.
 
-<a name="y" href="Stack-Layout#y">#</a> stack.<b>y</b>([<i>accessor</i>])
+<a name="y" href="Stack-Layout.md#y">#</a> stack.<b>y</b>([<i>accessor</i>])
 
 Specifies how to access the *y*-coordinate of each value's thickness. If *accessor* is specified, sets the accessor to the specified function. If *accessor* is not specified, returns the current function, which by default assumes that each input value has a y attribute:
 
@@ -142,7 +142,7 @@ function y(d) {
 
 The *y*-accessor is invoked for each input value, for each input layer, being passed the current data (d) and index (i). The return value of the accessor must be a number. With the exception of the "expand" offset, the stack layout does not perform any automatic scaling of data. To simplify scaling, use this layout in conjunction with a [linear scale](Quantitative-Scales.md#linear) or similar.
 
-<a name="out" href="Stack-Layout#out">#</a> stack.<b>out</b>([<i>setter</i>])
+<a name="out" href="Stack-Layout.md#out">#</a> stack.<b>out</b>([<i>setter</i>])
 
 Specifies how to propagate the computed baseline to above layers. If *setter* is specified, it is used as the output function. If *setter* is not specified, returns the current output function, which by default assumes that each input value has y and y0 attributes:
 

--- a/Time-Formatting.md
+++ b/Time-Formatting.md
@@ -4,7 +4,7 @@
 
 D3 includes a helper module for parsing and formatting dates modeled after the venerable [strptime](http://pubs.opengroup.org/onlinepubs/009695399/functions/strptime.html) and [strftime](http://pubs.opengroup.org/onlinepubs/007908799/xsh/strftime.html) C-library standards. These functions are also notably available in Python's [time](http://docs.python.org/library/time.html) module.
 
-<a name="format" href="Time-Formatting#format">#</a> d3.time.<b>format</b>(<i>specifier</i>)
+<a name="format" href="Time-Formatting.md#format">#</a> d3.time.<b>format</b>(<i>specifier</i>)
 
 Constructs a new local time formatter using the given *specifier*. (Equivalent to [locale.timeFormat](Localization.md#locale_timeFormat) for the default U.S. English locale.) The specifier string may contain the following directives.
 
@@ -53,7 +53,7 @@ format.parse("2011-01-01"); // returns a Date
 format(new Date(2011, 0, 1)); // returns a string
 ```
 
-<a name="_format" href="Time-Formatting#_format">#</a> <b>format</b>(<i>date</i>)
+<a name="_format" href="Time-Formatting.md#_format">#</a> <b>format</b>(<i>date</i>)
 
 Formats the specified *date*, returning the corresponding string. The *date* must be a JavaScript [Date](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date) object.
 
@@ -73,7 +73,7 @@ date = new Date(time); // convert a time in milliseconds to a Date object
 
 If you prefer to be explicit, you can also use the date object's [getTime](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/getTime) method, but the + operator is shorter and possibly faster.
 
-<a name="parse" href="Time-Formatting#parse">#</a> format.<b>parse</b>(<i>string</i>)
+<a name="parse" href="Time-Formatting.md#parse">#</a> format.<b>parse</b>(<i>string</i>)
 
 Parses the specified *string*, returning the corresponding date object. If the parsing fails, returns null. Unlike "natural language" date parsers (including JavaScript's built-in [parse](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/parse)), this method is strict: if the specified string does not exactly match the associated format specifier, this method returns null. For example, if the associated format is the full ISO 8601 string "%Y-%m-%dT%H:%M:%SZ", then the string "2011-07-01T19:15:28Z" will be parsed correctly, but "2011-07-01T19:15:28", "2011-07-01 19:15:28" and "2011-07-01" will return null, despite being valid 8601 dates. (Note that the hard-coded "Z" here is different from `%Z`, the time zone offset.) If desired, you can use multiple formats to try multiple format specifiers sequentially.
 
@@ -100,11 +100,11 @@ Thus, if the specified date is not a round second, the milliseconds format (`".%
 
 The **multi** method is available on any d3.time.format constructor. For example, [d3.time.format.utc](#format_utc).multi returns a multi-resolution UTC time format, and [locale.timeFormat](Localization.md#timeFormat).multi returns a multi-resolution time format for the specified locale.
 
-<a name="format_utc" href="Time-Formatting#format_utc">#</a> d3.time.format.<b>utc</b>(<i>specifier</i>)
+<a name="format_utc" href="Time-Formatting.md#format_utc">#</a> d3.time.format.<b>utc</b>(<i>specifier</i>)
 
 Constructs a new UTC time formatter using the given *specifier*. (Equivalent to [locale.timeFormat.utc](Localization.md#locale_timeFormat_utc) for the default U.S. English locale.) The specifier may contain the same directives as the local time [format](Time-Formatting.md#format). Internally, this time formatter is implemented using the UTC methods on the Date object, such as [getUTCDate](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/getUTCDate) and [setUTCDate](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/setUTCDate) in place of [getDate](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/getDate) and [setDate](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/setDate).
 
-<a name="format_iso" href="Time-Formatting#format_iso">#</a> d3.time.format.<b>iso</b>
+<a name="format_iso" href="Time-Formatting.md#format_iso">#</a> d3.time.format.<b>iso</b>
 
 The full [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) UTC time format: "%Y-%m-%dT%H:%M:%S.%LZ". Where available, this method will use [Date.toISOString](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Date/toISOString) to format and the [Date constructor](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Date) to parse strings. If you depend on strict validation of the input format according to ISO 8601, you should construct a time format explicitly instead:
 

--- a/Time-Scales.md
+++ b/Time-Scales.md
@@ -6,23 +6,23 @@ D3's **time scale** is an extension of [d3.scale.linear](Quantitative-Scales.md#
 
 A scale object, such as that returned by [d3.time.scale](Time-Scales.md#scale), is both an object and a function. That is: you can call the scale like any other function, and the scale has additional methods that change its behavior. Like other classes in D3, scales follow the method chaining pattern where setter methods return the scale itself, allowing multiple setters to be invoked in a concise statement.
 
-<a name="scale" href="Time-Scales#scale">#</a> d3.time.<b>scale</b>()
+<a name="scale" href="Time-Scales.md#scale">#</a> d3.time.<b>scale</b>()
 
 Constructs a new time scale with the default domain and range; the ticks and tick format are configured for local time.
 
-<a name="utc" href="Time-Scales#utc">#</a> d3.time.scale.<b>utc</b>()
+<a name="utc" href="Time-Scales.md#utc">#</a> d3.time.scale.<b>utc</b>()
 
 Constructs a new time scale with the default domain and range; the ticks and tick format are configured for UTC time.
 
-<a name="_scale" href="Time-Scales#_scale">#</a> <b>scale</b>(<i>x</i>)
+<a name="_scale" href="Time-Scales.md#_scale">#</a> <b>scale</b>(<i>x</i>)
 
 Given a date *x* in the input domain, returns the corresponding value in the output range.
 
-<a name="invert" href="Time-Scales#invert">#</a> scale.<b>invert</b>(<i>y</i>)
+<a name="invert" href="Time-Scales.md#invert">#</a> scale.<b>invert</b>(<i>y</i>)
 
 Returns the date in the input domain *x* for the corresponding value in the output range *y*. This represents the inverse mapping from range to domain. For a valid value *y* in the output range, scale(scale.invert(*y*)) equals *y*; similarly, for a valid date *x* in the input domain, scale.invert(scale(*x*)) equals *x*. The invert operator is particularly useful for interaction, say to determine the date in the input domain that corresponds to the pixel location under the mouse.
 
-<a name="domain" href="Time-Scales#domain">#</a> scale.<b>domain</b>([<i>dates</i>])
+<a name="domain" href="Time-Scales.md#domain">#</a> scale.<b>domain</b>([<i>dates</i>])
 
 If *dates* is specified, sets the scale's input domain to the specified array of dates. The array must contain two or more dates. If the elements in the given array are not dates, they will be coerced to dates; this coercion happens similarly when the scale is called. If *dates* is not specified, returns the scale's current input domain. Although time scales typically have just two dates in their domain, you can specify more than two dates for a *polylinear* scale. In this case, there must be an equivalent number of values in the output range.
 
@@ -33,24 +33,24 @@ Extends the domain so that it starts and ends on nice round values as determined
 
 This method typically extends the scale's domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [2009-07-13T00:02, 2009-07-13T23:48], the nice domain is [2009-07-13, 2009-07-14]. If the domain has more than two values, nicing the domain only affects the first and last value.
 
-<a name="range" href="Time-Scales#range">#</a> scale.<b>range</b>([<i>values</i>])
+<a name="range" href="Time-Scales.md#range">#</a> scale.<b>range</b>([<i>values</i>])
 
 If *values* is specified, sets the scale's output range to the specified array of values. The array must contain two or more values, to match the cardinality of the input domain. The elements in the given array need not be numbers; any value that is supported by the underlying [interpolator](Time-Scales.md#interpolate) will work. However, numeric ranges are required for the invert operator. If *values* is not specified, returns the scale's current output range.
 
-<a name="rangeRound" href="Time-Scales#rangeRound">#</a> scale.<b>rangeRound</b>([<i>values</i>])
+<a name="rangeRound" href="Time-Scales.md#rangeRound">#</a> scale.<b>rangeRound</b>([<i>values</i>])
 
 Sets the scale's output range to the specified array of values, while also setting the scale's interpolator to [d3.interpolateRound](Transitions.md#d3_interpolateRound). This is a convenience routine for when the values output by the scale should be exact integers, such as to avoid antialiasing artifacts. It is also possible to round the output values manually after the scale is applied.
 
-<a name="interpolate" href="Time-Scales#interpolate">#</a> scale.<b>interpolate</b>([<i>factory</i>])
+<a name="interpolate" href="Time-Scales.md#interpolate">#</a> scale.<b>interpolate</b>([<i>factory</i>])
 
 If *factory* is specified, sets the scale's output interpolator using the specified *factory*. The interpolator factory defaults to [d3.interpolate](Transitions.md#d3_interpolate), and is used to map the normalized domain parameter *t* in [0,1] to the corresponding value in the output range. The interpolator factory will be used to construct interpolators for each adjacent pair of values from the output range. If *factory* is not specified, returns the scale's interpolator factory.
 
-<a name="clamp" href="Time-Scales#clamp">#</a> scale.<b>clamp</b>([<i>boolean</i>])
+<a name="clamp" href="Time-Scales.md#clamp">#</a> scale.<b>clamp</b>([<i>boolean</i>])
 
 If *boolean* is specified, enables or disables clamping accordingly. By default, clamping is disabled, such that if a value outside the input domain is passed to the scale, the scale may return a value outside the output range through linear extrapolation. For example, with the default domain and range of [0,1], an input value of 2 will return an output value of 2. If clamping is enabled, the normalized domain parameter *t* is clamped to the range [0,1], such that the return value of the scale is always within the scale's output range. If *boolean* is not specified, returns whether or not the scale currently clamps values to within the output range.
 
-<a name="ticks" href="Time-Scales#ticks">#</a> scale.<b>ticks</b>([<i>interval</i>[, <i>step</i>]])
-<br><a name="ticks" href="Time-Scales#ticks">#</a> scale.<b>ticks</b>([<i>count</i>])
+<a name="ticks" href="Time-Scales.md#ticks">#</a> scale.<b>ticks</b>([<i>interval</i>[, <i>step</i>]])
+<br><a name="ticks" href="Time-Scales.md#ticks">#</a> scale.<b>ticks</b>([<i>count</i>])
 
 Returns representative dates from the scale's input domain. The returned tick dates are uniformly spaced (modulo irregular time intervals, such as months and leap years), have human-readable values (such as midnights), and are guaranteed to be within the extent of the input domain. Ticks are often used to display reference lines, or tick marks, in conjunction with the visualized data.
 
@@ -80,7 +80,7 @@ The following time intervals are considered for automatic ticks:
 
 This set of time intervals is somewhat arbitrary and additional values may be added in the future.
 
-<a name="tickFormat" href="Time-Scales#tickFormat">#</a> scale.<b>tickFormat</b>()
+<a name="tickFormat" href="Time-Scales.md#tickFormat">#</a> scale.<b>tickFormat</b>()
 
 Returns a [time format](Time-Formatting.md) function suitable for displaying a tick value. You don't have to use the scale's built-in tick format, but it automatically computes the appropriate display based on the input date.
 

--- a/Transitions.md
+++ b/Transitions.md
@@ -415,7 +415,7 @@ Returns an interpolator between the two 2D affine [transforms](Math.md#transform
 
 Returns a smooth [interpolator](#_interpolate) between the two views *a* and *b* of a two-dimensional plane, based on [“Smooth and efficient zooming and panning”](https://www.google.com/search?q=Smooth+and+efficient+zooming+and+panning) by Jarke J. van Wijk and Wim A.A. Nuij. Each view is defined as an array of three numbers: *cx*, *cy* and *width*. The first two coordinates *cx*, *cy* represent the center of the viewport; the last coordinate *width* represents the size of the viewport. The returned interpolator also has a *duration* property which encodes the recommended transition duration in milliseconds. This duration is based on the path length of the curved trajectory through *x,y* space. If you want to a slower or faster transition, multiply this by an arbitrary scale factor (<i>V</i> as described in the original paper).
 
-<a href="Geo-Paths#interpolate">#</a> d3.geo.<b>interpolate</b>(<i>a</i>, <i>b</i>)
+<a href="Geo-Paths.md#interpolate">#</a> d3.geo.<b>interpolate</b>(<i>a</i>, <i>b</i>)
 
 See [d3.geo.interpolate](Geo-Paths.md#interpolate).
 

--- a/Zoom-Behavior.md
+++ b/Zoom-Behavior.md
@@ -58,7 +58,7 @@ Specifies an _x_-scale whose domain should be automatically adjusted when zoomin
 
 Specifies an _y_-scale whose domain should be automatically adjusted when zooming. If not specified, returns the current _y_-scale, which defaults to null. If the scale's domain or range is modified programmatically, this function should be called again. Setting the _y_-scale also resets the scale to 1 and the translate to [0, 0].
 
-<a name="on" href="Zoom-Behavior#on">#</a> zoom.<b>on</b>(<i>type</i>, <i>listener</i>)
+<a name="on" href="Zoom-Behavior.md#on">#</a> zoom.<b>on</b>(<i>type</i>, <i>listener</i>)
 
 Registers the specified *listener* to receive events of the specified *type* from the zoom behavior. The following types are supported:
 


### PR DESCRIPTION
Hello - I know d3v3 is dead, but I was fixing the documentation links in dc.js while getting ready to upgrade to d3v4.

I noticed that the anchor self-links in the v3 documentation are broken, in the case where they refer to the filename explicitly. E.g. try clicking on the hash to the left of 

https://github.com/d3/d3-3.x-api-reference/blob/master/Selections.md#d3_select

I use the self-links all the time when helping folks, so I thought it would be helpful to fix these. Thanks!